### PR TITLE
automatically open to make a new discussion page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Feature Request
     url: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions/new
-    about: Please create feature requests in the Discussions tab.
+    about: Please create feature requests in the Discussions tab. If you tap open, it will take you to the page where you must start writing your feature request. Please put it under the catergory of Ideas.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Feature Request
-    url: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions
+    url: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions/new
     about: Please create feature requests in the Discussions tab.


### PR DESCRIPTION
# Related Issue/Addition to code

- Right now, when a user taps "Open" it just takes them to the discussions page, but if they tap that they want to make a discussion with a idea so with /new it takes them straight to the page to create a new discussion which the purpose of that is, so it saves the person of some extra clicks. 

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Proposed Changes
- Add /new in the link to take them to the discussions page, where they can start their discussion immediately.
