### PR TITLE
Add: log_path option +

### DIFF
--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -35,7 +35,7 @@
 ### IMPORTANT:  I OFFER NO WARRANTY OR GUARANTEE FOR THIS SCRIPT. USE AT YOUR OWN RISK.
 ###             I tested it on my own and implemented some failsafes as best as I could,
 ###             but there could always be some kind of bug. You should inspect the code yourself.
-version = "2.2.6"
+version = "2.3.0"
 configVersion = 11
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
@@ -1447,8 +1447,8 @@ def load_config_file():
     #configDictRaw = {s:dict(parser.items(s)) for s in parser.sections()}
 
     # Convert raw config dictionary into easier to use dictionary
-    settingsToKeepCase = ["your_channel_id", "video_to_scan", "channel_ids_to_filter", "regex_to_filter", "channel_to_scan"]
-    validWordVars = ['ask', 'mine']
+    settingsToKeepCase = ["your_channel_id", "video_to_scan", "channel_ids_to_filter", "regex_to_filter", "channel_to_scan", "log_path"]
+    validWordVars = ['ask', 'mine', 'default']
     configDict = {}
     for section in parser.sections():
       for setting in parser.items(section):
@@ -2518,11 +2518,13 @@ def main():
     if logMode == True:
       global logFileName
       fileName = "Spam_Log_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S" + ".rtf")
-      if config and config['log_path']:
+      if config and config['log_path'] and config['log_path'] != "default":
           logFileName = os.path.normpath(config['log_path'] + "/" + fileName)
+          print(f"Log file will be located at {F.YELLOW}" + logFileName + f"{S.R}\n")
       else:
           logFileName = fileName
-      print(f"Log file will be called {F.YELLOW}" + logFileName + f"{S.R}\n")
+          print(f"Log file will be called {F.YELLOW}" + logFileName + f"{S.R}\n")
+      
       if bypass == False:
         input(f"Press {F.YELLOW}Enter{S.R} to display comments...")
 

--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -36,7 +36,7 @@
 ###             I tested it on my own and implemented some failsafes as best as I could,
 ###             but there could always be some kind of bug. You should inspect the code yourself.
 version = "2.2.6"
-configVersion = 10
+configVersion = 11
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
 # GUI Related
@@ -2517,7 +2517,11 @@ def main():
 
     if logMode == True:
       global logFileName
-      logFileName = "Spam_Log_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S" + ".rtf")
+      fileName = "Spam_Log_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S" + ".rtf")
+      if config and config['log_path']:
+          logFileName = os.path.normpath(config['log_path'] + "/" + fileName)
+      else:
+          logFileName = fileName
       print(f"Log file will be called {F.YELLOW}" + logFileName + f"{S.R}\n")
       if bypass == False:
         input(f"Press {F.YELLOW}Enter{S.R} to display comments...")

--- a/assets/default_config.ini
+++ b/assets/default_config.ini
@@ -4,7 +4,7 @@
 # • If you set a setting in here, the program will not Ask you to enter/confirm when your run it
 # • If you leave the value as 'Ask', the program will Ask you for it as usual
 # • Some settings might not be necessary depending on which modes you select
-# 
+#
 # • For 100% automatic usage of program, enter all values (or at least all for your scanning/filtering modes)
 # • NOTE: Human confirmation is required for most settings to actually remove comments
 #	- If comment removal is automated, comments are marked as "held for review" and hidden
@@ -29,6 +29,13 @@ your_channel_id = Ask
 	# Enable log file generation: 'True' or 'False'
 	# Default = Ask  --  Possible Values: Ask | True | False
 enable_logging = Ask
+
+	# Set the log file path
+  # This only sets the path; the file name will be generated
+  # Default = current directory
+  #
+  # log_path = C:\logfiles
+  # log_path = /home/user/logfiles
 
 	# Enables or disables silent checking of newer version when program runs. Only displays message if update is available
 	# This will not display errors if it cannot get version. To see any issues, use program's manual update check
@@ -105,7 +112,7 @@ strings_to_filter = Ask
 	# Default = Ask  --  Possible Values: Ask | [regex]
 regex_to_filter = Ask
 
-	
+
 [removal]
 #--------------------------------------------------------------------------------
 	# If 'False', behaves as normal. If 'True', simply skips deletion altogether and exits program, Good if you just want to collect logs.
@@ -133,4 +140,4 @@ removal_type = rejected
 
 # Don't change anything below here!
 [info]
-config_version = 10
+config_version = 11

--- a/assets/default_config.ini
+++ b/assets/default_config.ini
@@ -30,12 +30,9 @@ your_channel_id = Ask
 	# Default = Ask  --  Possible Values: Ask | True | False
 enable_logging = Ask
 
-	# Set the log file path
-  # This only sets the path; the file name will be generated
-  # Default = current directory
-  #
-  # log_path = C:\logfiles
-  # log_path = /home/user/logfiles
+	# Set the FULL folder path where log files will go (not including file name itself). Ensure write permissions to path.
+	# Default = Default (Sets to current directory)  -- Example Values: C:\Users\wherever\  |  /home/user/logfiles
+log_path = Default
 
 	# Enables or disables silent checking of newer version when program runs. Only displays message if update is available
 	# This will not display errors if it cannot get version. To see any issues, use program's manual update check


### PR DESCRIPTION
  Allows for setting a path for log files,
  storing them outside current working
  directory.

- Fixes #210

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Proposed Changes
- Add log_path to (default) config
- Prepend `logFileName` with `log_path`, if set

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
