### PR TITLE
auto assign thiojoe to review pr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto assign Thiojoe as a PR reviewer
+* @ThioJoe


### PR DESCRIPTION
# Related Issue/Addition to code

- Auto-assign @ThioJoe as a PR reviewer

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Added code-owners file
- Made it so that ThioJoe will automatically be assigned as a reviewer for PR's in this repo.


