### PR TITLE
remove link of github attachement for the icon, link the icon from the assets folder instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-<img src="https://raw.githubusercontent.com/ThioJoe/YT-Spammer-Purge/main/assets/icon.png" alt="Icon" width="120" height="120" </img>
+<img src="/assets/icon.png" alt="Icon" width="120" height="120" </img>
 <br>
 YouTube Spammer Purge
 <br>


### PR DESCRIPTION
# Related Issue/Addition to code

- Extra long attachment link

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Link the icon from the assets folder

