### PR TITLE
link to file instead of wiki for linux setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ YouTube Spammer Purge
 **What Is This?** - Allows you to filter and search for spammer comments on your channel and other's channel(s) in many different ways AND delete/report them all at once (see features below).
 
 **How to Download:** Click the "[Releases](https://github.com/ThioJoe/YouTube-Spammer-Purge/releases)" link on the right, then on the latest release, under 'Assets' click to download "YouTubeSpammerPurge.exe". NOTE: You may get a warning - See "[Download & Windows Warning](#download--windows-warning)" section below for details.
-> * [Linux Setup Instructions](https://github.com/ThioJoe/YouTube-Spammer-Purge/wiki/Linux-Installation-Instructions)
+> * [Linux Setup Instructions](Linux-Installation-Instructions.md)
 > * [MacOS Setup Instructions](https://github.com/ThioJoe/YouTube-Spammer-Purge/wiki/MacOS-Instructions)
 > * (Windows installation not necessary if using exe file. But read below for how to set up required API key)
 


### PR DESCRIPTION
# Related Issue/Addition to code

- There is a Linux-Installation-Instructions.md with more info then the wiki, but the link to "Linux Setup" is to the wiki.

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Updated path to go to file instead of wiki
