### PR TITLE
Add the other method of attaching a screenshot in Bug Report issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -70,4 +70,4 @@ body:
     id: screenshots
     attributes:
       label: Screenshots
-      description: (Screenshots can be uploaded by simply dragging an image file into this box)
+      description: (Screenshots can be uploaded by simply dragging an image file into this box or by copying the image into your clipboard and pasting it in the box.)


### PR DESCRIPTION
# Related Issue/Addition to code

- Other method of attaching screenshot missing

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Add the other method of attaching a screenshot.
