### PR TITLE
Update install_full for Fedora dependencies

### DIFF
--- a/install_full.sh
+++ b/install_full.sh
@@ -25,10 +25,11 @@ else
 fi
 #install tkinter, a dependency
 #install jq, needed to get version number
+#install GCC and Python3 headers on Fedora, since python-Levenshtein needs to be compiled there.
 if [[ -e /etc/debian_version ]]; then
 	sudo apt install python3-tk jq python3-pip
 elif [[ -e /etc/fedora-release ]]; then
-	sudo dnf --assumeyes --quiet install python3-tkinter jq python3-pip
+	sudo dnf --assumeyes --quiet install python3-tkinter jq python3-pip gcc python3-devel
 elif [[ -e /etc/centos-release ]]; then
 	rpm -q epel-release &> /dev/null || EPEL=0 
 	sudo yum install -y python3-tkinter epel-release python3-pip


### PR DESCRIPTION
Fedora needs additional python dependencies for the python-Levenshtein to successfully install.

# Related Issue/Addition to code

- Fixes # https://github.com/ThioJoe/YT-Spammer-Purge/issues/441

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes
- Install GCC and Python3 headers before running pip

# Additional Info
- It looks like the Levenshtein does not have compatible wheels for fedora, so it needs to be built from source.

## Checklist:

- [X] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

