### PR TITLE
Replace long link to report bugs to short link on line 1268

### DIFF
--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -1265,8 +1265,7 @@ def main():
     if returnToMenu == False and deletionEnabled != "Allowed" and deletionEnabled != True:
         print("\nThe deletion functionality was not enabled. Cannot delete or report comments.")
         print("Possible Cause: You're scanning someone elses video with a non-supported filter mode.\n")
-        print("If you think this is a bug, you may report it on this project's GitHub page: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
-	print("Short Url: https://tjoe.io/bug-report")
+        print("If you think this is a bug, you may report it on this project's GitHub page: https://tjoe.io/bug-report")
         if config['auto_close'] == True:
           print("\nAuto-close enabled in config. Exiting in 5 seconds...")
           time.sleep(5)

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -1266,6 +1266,7 @@ def main():
         print("\nThe deletion functionality was not enabled. Cannot delete or report comments.")
         print("Possible Cause: You're scanning someone elses video with a non-supported filter mode.\n")
         print("If you think this is a bug, you may report it on this project's GitHub page: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
+	print("Short Url: https://tjoe.io/bug-report")
         if config['auto_close'] == True:
           print("\nAuto-close enabled in config. Exiting in 5 seconds...")
           time.sleep(5)


### PR DESCRIPTION
# Related Issue/Addition to code

- #484 
- Python is not like HTML where you can just tap text and have the link opened in a new tab, so to make it more convenient for the user, I listed the short url to report bugs too

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Proposed Changes
- Replaced the github long url of the issues page with the short url


