### PR TITLE
Update dockerfile to slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3-slim
 
 WORKDIR /usr/src/app
 RUN apt update
-RUN apt install -y python3-tk
+RUN apt install -y python3-tk gcc
 ADD Scripts ./Scripts
 ADD assets ./assets
 COPY requirements.txt YTSpammerPurge.py ./


### PR DESCRIPTION
- Fixes #
- Changing to the python:3-slim image and installing required dependencies reduces the image size from ~1GB to 377MB

# Proposed Changes
- Change base image from python:3 to python:3-slim
- Install required dependency gcc during build

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
