### PR TITLE
Update discussion link in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -10,7 +10,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
         
-        IS THIS A FEATURE REQUEST OR IDEA? SUBMIT A DISCUSSION POST INSTEAD HERE: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions
+        IS THIS A FEATURE REQUEST OR IDEA? SUBMIT A DISCUSSION POST INSTEAD HERE: https://github.com/ThioJoe/YT-Spammer-Purge/discussions
   - type: checkboxes
     id: no-issues-relating-to-this
     attributes:


### PR DESCRIPTION
This doesn't change functionality as GitHub redirected you back, but there is no harm in updating the links.