### PR TITLE
Update discussion link in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Feature Request
-    url: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions
+    url: https://github.com/ThioJoe/YT-Spammer-Purge/discussions
     about: Please create feature requests in the Discussions tab.

--- a/.github/ISSUE_TEMPLATE/spam_detection.yaml
+++ b/.github/ISSUE_TEMPLATE/spam_detection.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |      
-        IS THIS A FEATURE REQUEST OR IDEA? SUBMIT A DISCUSSION POST INSTEAD HERE: https://github.com/ThioJoe/YouTube-Spammer-Purge/discussions
+        IS THIS A FEATURE REQUEST OR IDEA? SUBMIT A DISCUSSION POST INSTEAD HERE: https://github.com/ThioJoe/YT-Spammer-Purge/discussions
   - type: dropdown
     id: filter-mode
     attributes:


### PR DESCRIPTION
# Related Issue/Addition to code

- Fixes #512
- Update link for discussions page in issue templates.

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Update link for discussions page in 2 issue templates

# Additional Info
- PLEASE NOTE: The current url works too, but the new url looks better, according to me
- @TechStudent11 Already did this for one issue template (bug_report.yaml) but didnt do it for the other 2 templates, so I did this now.
