### PR TITLE
Added a disclaimer message, if you download releases before, the certificate was bought

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Either way, you DO need to acquire your own API credentials file to access the Y
 * [Linux Setup Instructions](https://github.com/ThioJoe/YouTube-Spammer-Purge/wiki/Linux-Installation-Instructions)
 * [MacOS Setup Instructions](https://github.com/ThioJoe/YouTube-Spammer-Purge/wiki/MacOS-Instructions)
 
+Please note: If you download old versions of this project, please note that Windows Security, antivirus softwares will give you a popup saying "This exe file is not downloaded from a identified source", it was giving this error because I did not have a Certificate, My certificate arrived in early Jan so the popup won't be there in later releases.
+
 
 
 **Docker Instructions:**


### PR DESCRIPTION
# Related Issue/Addition to code

- If user downloads old releases, the popup saying this isnt safe still shows up

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Put a disclaimer

# Additional Info
- @ThioJoe You can include the date the certificate arrived and also the last release where this popup showed. If people want to do testing of the previous versions, coz they can download the program, I mean some people will, but the majority wont so I think its good to add this caution message.
- @ThioJoe[](https://github.com/KendallDoesCoding) This is a disclaimer, so feel free to make it bold, if you want.

