### PR TITLE
Gracefully handle input which contains leading/trailling comma

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -826,6 +826,7 @@ def exclude_authors(current, config, miscData, excludedCommentsDict, authorsToEx
         inputtedString = input("\nEnter the list of only authors to delete: ")
       
     else:
+      result = result.strip(',') # Remove leading/trailing comma
       result = utils.expand_ranges(result) # Expands ranges of numbers into a list of numbers
       chosenSampleIndexes = result.split(",")
       valid = True


### PR DESCRIPTION
# Related Issue/Addition to code
- Strip leading/trailing comma in "exclude_authors" input

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshots

Original | Updated
:----------------------:|:-----------:
![2022-02-03 12_24_16-Window](https://user-images.githubusercontent.com/752127/152338766-f8aa8448-af06-414a-abf4-0995ebcd8312.png)|![2022-02-03 12_58_31-Window](https://user-images.githubusercontent.com/752127/152338794-f349da59-66c2-4f7c-b8ba-e08ff58e9411.png)
