### PR TITLE
Add a messege that you will not be able to add run the exe file under Windows 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
-The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows)
+The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). A resolution to this can be fixed by downloading the latest driver, for some computers located [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
+If your using the exe version (not the python script) on a Windows computer, under Windows 8, you will not be able to run the exe version because dll (a component of this project) was only added in Windows 8 and above. Although, the Python Script should work fine, incase of any issues, feel free to report bugs [here](https://github.com/ThioJoe/YT-Spammer-Purge/issues/new/choose) 
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
+
 The Windows .EXE version may not run on systems older than Windows 8 [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
-The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). A resolution to this can be fixed by downloading the latest driver, for some computers located [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
+The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 <p align="center"><img width="738" alt="Match Samples and Deletion Menu" src="https://user-images.githubusercontent.com/93459510/147559013-7b1f59c7-4433-4b19-8e2e-7988d5d29ee5.png"></p>
 
 ## Installation
+The Windows .EXE version may not run on systems older than Windows 8 [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7.
-
-The Windows .EXE version may not run on systems older than Windows 8 [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
-If your using the exe version (not the python script) on a Windows computer, under Windows 8, you will not be able to run the exe version because dll (a component of this project) was only added in Windows 8 and above. Although, the Python Script should work fine, incase of any issues, feel free to report bugs [here](https://github.com/ThioJoe/YT-Spammer-Purge/issues/new/choose) 
+The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows)
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 
 ## Installation
 
-If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
+If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7.
 
 The Windows .EXE version may not run on systems older than Windows 8 [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Read some additional details about 'moderator mode' on the [wiki page here](http
 ## Installation
 
 If using the python script version (not the exe), there is a requirements.txt with necessary modules. Created with Python 3.9.7
-The Windows .EXE version requires Windows 8 or above [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
+The Windows .EXE version may not run on systems older than Windows 8 [(Why?)](https://pyinstaller.readthedocs.io/en/stable/requirements.html#windows). This can be fixed by installing Microsoft's "Universal C Runtime" for your system [here](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
 Either way, you DO need to acquire your own API credentials file to access the YouTube API - [See Instructions Here](https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key).
 


### PR DESCRIPTION
# Related Issue/Addition to code

- dll was only added in Windows 8, users wont be able to run exe on computers below Windows 8

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Added a disclaimer message (If your using the exe file on a version below Windows 8, the exe file wont run properly because dll was only added in Windows 8)
- Added full stop after created with Python 3.9.7.

# Additional Info
- @ThioJoe This is a disclaimer, so feel free to make it bold, if you want.
