### PR TITLE
Use `else` instead of `elif`

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -42,7 +42,7 @@ def get_comments(current, filtersDict, miscData, config, currentVideoDict, scanV
       ).execute()
     
     # Get all comment threads across the whole channel
-    elif scanVideoID is None:
+    else:
       results = auth.YOUTUBE.commentThreads().list(
         part="snippet, replies",
         allThreadsRelatedToChannelId=auth.CURRENTUSER.id,


### PR DESCRIPTION
Basic, refactoring to simplify code. Use `else` instead of `elif scanVideoID is None` in `get_comments`