### PR TITLE
Fix default config file options

### DIFF
--- a/assets/default_config.ini
+++ b/assets/default_config.ini
@@ -182,6 +182,7 @@ minimum_duplicates = 8
 	# Minimum number of characters a comment must have to be considered when checking duplicates
 	# The threshold is 'greater than or equal to' the number entered
 	# Note: In some special circumstances (such as a comment containing a domain name), this number may be overridden
+	# Default = 14  --  Possible Values: [Any integer above 0] 
 minimum_duplicate_length = 14
 
 	# Determines at least how similar two comments must be to be considered a duplicate
@@ -195,7 +196,7 @@ levenshtein_distance = 0.9
 	# If a commenter has already been marked as a match, all their comments will be removed and won't show here
 	# For multiple, must be comma separated list. To disable duplicate scanning altogether, enter only 'None'
 	# NOTE: Currently does not work for Community Posts and Entire Channel Mode
-	# Default = AutoSmart, SensitiveSmart  --  Possible Values:  None | ID | Username | Text | NameAndText | AutoASCII | AutoSmart | SensitiveSmart
+	# Default = SensitiveSmart  --  Possible Values:  None | ID | Username | Text | NameAndText | AutoASCII | AutoSmart | SensitiveSmart
 stolen_comments_check_modes = SensitiveSmart
 
 	# The minimum length a comment must be before it is checked against other comments for similarity.


### PR DESCRIPTION
I noticed 2 small errors in the default config file and it was easy enough for me to fix

In the `stolen_comments_check_modes` values it has the auto-smart mode whereas it should not be there
https://github.com/ThioJoe/YT-Spammer-Purge/blob/f407440f7e1c282ef0f93cae9c15ee1384471f4e/assets/default_config.ini#L198-L199

---

`minimum_duplicate_length` is the only value not to list its default
https://github.com/ThioJoe/YT-Spammer-Purge/blob/f407440f7e1c282ef0f93cae9c15ee1384471f4e/assets/default_config.ini#L184-L185


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes

- Added missing default for `minimum_duplicate_length`
- Corrected default for `stolen_comments_check_modes`

## Checklist:

- [X] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

# Screenshots

Original | Updated
:----------------------:|:-----------:
![gitkraken_GitKraken (3)](https://user-images.githubusercontent.com/34950371/154392975-d3e3cfce-1fa4-4472-a9bd-106c4e6dd0f2.png)  | ![gitkraken_GitKraken (4)](https://user-images.githubusercontent.com/34950371/154392995-819ae976-9e93-4ab8-a650-28d3bbc8d75f.png)