### PR TITLE
MacOS: tcl-tk needed to be installed using brew to run script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,7 @@ install_macos() {
     fi
     # Install python3.10 & git or fail out
     brew install python@3.10 && \
+    brew install tcl-tk && \
     brew install git || \
         install_fail
 }

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,7 @@ install_macos() {
     # Install python3.10 & git or fail out
     brew install python@3.10 && \
     brew install tcl-tk && \
+    brew install python-tk && \
     brew install git || \
         install_fail
 }


### PR DESCRIPTION
# Related Issue/Addition to code

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes
- Added installing tcl-tk and python-tk on the script for mac

# Additional Info
before: error on `import _tkinter # If this fails your Python may not be configured for Tk`
after: works well
It was first found on issue #523 but still not fixed in script

I checked that someone needs to be installed as `brew install python-tk` and someone needs `brew install tcl-tk` so I am wondering how to check this

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

