### PR TITLE
add python3-dev to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ install_fail () {
 }
 
 install_debian () {
-    sudo apt install python3 python3-tk python3-pip git || install_fail
+    sudo apt install python3 python3-dev python3-tk python3-pip git || install_fail
 }
 
 install_fedora () {


### PR DESCRIPTION
to prevent error during installation on ubuntu 21.10: (probably all ubuntu versions)

``` 
      x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-secur
ity -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.9 -c Le
venshtein/_levenshtein.c -o build/temp.linux-x86_64-3.9/Levenshtein/_levenshtein.o
      Levenshtein/_levenshtein.c:99:10: fatal error: Python.h: No such file or directory
         99 | #include <Python.h>
            |          ^~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
      [end of output]
```

- Fixes #721
- Issue/Addition to code, goes here.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

