### PR TITLE
more faster platform identification

### DIFF
--- a/Scripts/files.py
+++ b/Scripts/files.py
@@ -304,7 +304,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
             print(f" > And don't forget to report any problems you encounter here: {F.YELLOW}TJoe.io/bug-report{S.R}")
           input("\nPress Enter to Exit...")
           sys.exit()
-        elif platform.system() == "Linux":
+        elif os.name == "posix":
           # Current working directory
           cwd = os.getcwd()
           # what we want the tar file to be called on the system

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -60,7 +60,6 @@ import ast
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from collections import namedtuple
-import platform
 import json
 from pkg_resources import parse_version
 
@@ -102,7 +101,7 @@ def main():
 
   # Checks system platform to set correct console clear command
   # Clears console otherwise the windows terminal doesn't work with colorama for some reason  
-  clear_command = "cls" if platform.system() == "Windows" else "clear"
+  clear_command = "cls" if (os.name == 'nt') else "clear"
   os.system(clear_command)
 
   print("\nLoading YT Spammer Purge @ " + str(version) + "...")


### PR DESCRIPTION
- Fixes #
- Issue/Addition to code, goes here.

```python
platform.system() # is slower than
os.name # this
# + there will be no need to import platform only for this purpose
```

## Type of change

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings