### PR TITLE
Update recent videos max amount in config

### DIFF
--- a/assets/default_config.ini
+++ b/assets/default_config.ini
@@ -102,8 +102,8 @@ videos_to_scan = Ask
 channel_to_scan = Ask
 
 	# For Recent Video (and Recent Community Post) scanning modes, how many recent videos/posts to scan.
-	# For videos, up to 500 (the YouTube API Limit). For community posts, it varies by channel, but usually ~5-10 tops
-	# Default = Ask -- Possible Values: Ask | 1 - 500
+	# For videos, up to 5000 (the YouTube API Limit). For community posts, it varies by channel, but usually ~5-10 tops
+	# Default = Ask -- Possible Values: Ask | 1 - 5000
 recent_videos_amount = Ask
 
 


### PR DESCRIPTION
# Related Issue/Addition to code
Please delete options that are not relevant.

- Fixes #767


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Proposed Changes
- Update `recent_videos_amount` info comments to show max of 5000 videos.

# Additional Info
- Obviously will need a config version number update.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
