### PR TITLE
Add comments to info in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 # Related Issue/Addition to code
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - Fixes #
 - Issue/Addition to code, goes here.
 
 ## Type of change
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)


### PR DESCRIPTION
# Related Issue/Addition to code
It's very annoying to always remove these 2 lines when making a PR, so I commented them out so that users don't have to remove the lines, but they won't show in the PR regardless if removed or no!

## Type of change
- [ ] This change requires a documentation update

# Proposed Changes
- Comment out 2 lines in PR template (lines = info for user)
