### PR TITLE
Shrink size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
+FROM python:3-slim AS builder
+
+RUN apt-get update && \
+    apt-get install -y gcc
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --user -r requirements.txt
+
 FROM python:3-slim
 
 WORKDIR /usr/src/app
-RUN apt-get update && apt-get install -y \
-    python3-tk \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y libtk8.6 && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /root/.local /root/.local
+
+COPY YTSpammerPurge.py ./
 ADD Scripts ./Scripts
 ADD assets ./assets
-COPY requirements.txt YTSpammerPurge.py ./
-RUN pip install --no-cache-dir -r requirements.txt
 
 CMD [ "python", "./YTSpammerPurge.py" ]


### PR DESCRIPTION
# Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

This PR shrinks the size of the Docker image by nearly 50% (from 417 MB to 222 MB) by only including the necessary runtime dependencies. The savings are achieved by separating the Dockerfile into a build and runtime stage and only including runtime dependencies in the final image.
 
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactoring / Optimization

# Proposed Changes
- Drop `gcc` from the final image, because is only needed to build a Python package, not at runtime
- Replace [`python3-tk`](https://packages.debian.org/bullseye/python3-tk), because
  - the base image (`python:3-slim`) already includes the Python library tkinter
  - the thereby installed Python library won't be used anyways, because it's for Python 3.9, no 3.10.
  - only the runtime library [`libtk8.6`](https://packages.debian.org/bullseye/libtk8.6) is needed
- Build wheel for `python-Levenshtein` in the build stage and copy the results to the final image, leaving the build dependencies behind
