### PR TITLE
Reduce Youtube API Quota usage

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -1366,7 +1366,7 @@ def get_recent_videos(current, channel_id, numVideosTotal):
     #fetch the channel resource
     channel = auth.YOUTUBE.channels().list(
       part="contentDetails",
-      channelId=channel_id).execute()
+      id=channel_id).execute()
     
     #get the "uploads" playlist
     uploadplaylistId = channel['items'][0]['contentDetails']['relatedPlaylists']['uploads']
@@ -1380,7 +1380,8 @@ def get_recent_videos(current, channel_id, numVideosTotal):
       ).execute()
 
     for item in result['items']:
-      videoID = str(item['id']['videoId'])
+      print(item)
+      videoID = str(item['snippet']['resourceId']['videoId'])
       videoTitle = str(item['snippet']['title']).replace("&quot;", "\"").replace("&#39;", "'")
       commentCount = validation.validate_video_id(videoID, pass_exception = True)[3]
       #Skips over video if comment count is zero, or comments disabled / is live stream

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -1363,13 +1363,19 @@ def exclude_authors(current, config, miscData, excludedCommentsDict, authorsToEx
 # Returns a list of lists
 def get_recent_videos(current, channel_id, numVideosTotal):
   def get_block_of_videos(nextPageToken, j, k, numVideosBlock = 50):
-    result = auth.YOUTUBE.search().list(
+    #fetch the channel resource
+    channel = auth.YOUTUBE.channels().list(
+      part="contentDetails",
+      channelId=channel_id).execute()
+    
+    #get the "uploads" playlist
+    playlistId = response['items'][0]['contentDetails']['relatedPlaylists']['uploads']
+    
+    #fetch videos in the playlist
+    result = auth.YOUTUBE.playlistItems().list(
       part="snippet",
-      channelId=channel_id,
-      type='video',
-      order='date',
+      playlistId=playlistId,
       pageToken=nextPageToken,
-      #fields='nextPageToken,items/id/videoId,items/snippet/title',
       maxResults=numVideosBlock,
       ).execute()
 

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -1380,7 +1380,6 @@ def get_recent_videos(current, channel_id, numVideosTotal):
       ).execute()
 
     for item in result['items']:
-      print(item)
       videoID = str(item['snippet']['resourceId']['videoId'])
       videoTitle = str(item['snippet']['title']).replace("&quot;", "\"").replace("&#39;", "'")
       commentCount = validation.validate_video_id(videoID, pass_exception = True)[3]

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -1369,12 +1369,12 @@ def get_recent_videos(current, channel_id, numVideosTotal):
       channelId=channel_id).execute()
     
     #get the "uploads" playlist
-    playlistId = response['items'][0]['contentDetails']['relatedPlaylists']['uploads']
+    uploadplaylistId = channel['items'][0]['contentDetails']['relatedPlaylists']['uploads']
     
     #fetch videos in the playlist
     result = auth.YOUTUBE.playlistItems().list(
       part="snippet",
-      playlistId=playlistId,
+      playlistId=uploadplaylistId,
       pageToken=nextPageToken,
       maxResults=numVideosBlock,
       ).execute()


### PR DESCRIPTION
# Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Fixes #
- Reduce youtube API Quota Usage

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes


# Additional Info
- The YouTube Quota usage is listed here: https://developers.google.com/youtube/v3/determine_quota_cost, The cost for a youtube "search" is "100" Quota, whereas fetching the Channel resource and then the channels "uploads" Playlist are 1 each.  This should, in theory, reduce quota usage by a lot allowing people to scan more videos/comments. Its possible the Channel resource only needs fetching once but I wasn't sure how this project implements persistent data and may be open to more bugs so left the interfaces as they were.  

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
