### PR TITLE
Get uploads in once

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -1362,15 +1362,8 @@ def exclude_authors(current, config, miscData, excludedCommentsDict, authorsToEx
 ################################# Get Most Recent Videos #####################################
 # Returns a list of lists
 def get_recent_videos(current, channel_id, numVideosTotal):
+  uploadplaylistId = utils.get_uploads_playlist_id(channel_id) # Getting uploads ID in here.
   def get_block_of_videos(nextPageToken, j, k, numVideosBlock = 50):
-    #fetch the channel resource
-    channel = auth.YOUTUBE.channels().list(
-      part="contentDetails",
-      id=channel_id).execute()
-    
-    #get the "uploads" playlist
-    uploadplaylistId = channel['items'][0]['contentDetails']['relatedPlaylists']['uploads']
-    
     #fetch videos in the playlist
     result = auth.YOUTUBE.playlistItems().list(
       part="snippet",
@@ -1381,7 +1374,7 @@ def get_recent_videos(current, channel_id, numVideosTotal):
 
     for item in result['items']:
       videoID = str(item['snippet']['resourceId']['videoId'])
-      videoTitle = str(item['snippet']['title']).replace("&quot;", "\"").replace("&#39;", "'")
+      videoTitle = str(item['snippet']['title']) # Video title been HTML unescaped. So no need to replace.
       commentCount = validation.validate_video_id(videoID, pass_exception = True)[3]
       #Skips over video if comment count is zero, or comments disabled / is live stream
       if str(commentCount) == '0':

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -216,7 +216,6 @@ def print_error_title_fetch():
 
 
 # Fetch the uploads playlist ID for the channel
-# By DinhHuy2010 at GitHub
 
 def get_uploads_playlist_id(channel_id):
   try:

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -213,3 +213,15 @@ def print_error_title_fetch():
   print(f"  > You won't be able to delete/hide any comments like usual, but you can {F.LIGHTMAGENTA_EX}exclude users before saving the log file{S.R}")
   print(f"  > Then, you can {F.LIGHTGREEN_EX}delete the comments later{S.R} using the {F.YELLOW}mode that removes comments using a pre-existing log file{S.R}")
   input("\n Press Enter to continue...")
+
+
+# Fetch the uploads playlist ID for the channel
+# By DinhHuy2010 at GitHub
+
+def get_uploads_playlist_id(channel_id):
+  try:
+    channel = auth.YOUTUBE.channels.list(part="contentDetails", id=channel_id).execute()
+    uploadplaylistId = channel["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
+  except HttpError:
+    uploadplaylistId = "[Unavailable]" # If raise HttpError, set to [Unavailable]
+  return uploadplaylistId

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -478,8 +478,8 @@ def main():
             print(f"\nEnter a list of {F.YELLOW}Video Links{S.R} or {F.YELLOW}Video IDs{S.R} to scan, separated by commas.")
             print(" > Note: All videos must be from the same channel.")
             enteredVideosList = utils.string_to_list(input("\nEnter here: "))
-            if str(enteredVideosList).lower() == "['x']":
-              return True # Return to main menu
+            if len(enteredVideosList) == 1 and str(enteredVideosList[0]).lower() == "x":
+              return True
             validConfigSetting = False
             if len(enteredVideosList) == 0:
               listNotEmpty = False
@@ -493,32 +493,34 @@ def main():
           videoListResult = [] # True/False, video ID, videoTitle, commentCount, channelID, channelTitle
           for i in range(len(enteredVideosList)):
             videoListResult.append([])
-            videosToScan.append({})
             videoListResult[i] = validation.validate_video_id(enteredVideosList[i]) # Sends link or video ID for isolation and validation
             if videoListResult[i][0] == False:
+              print(f"\nInvalid Video: {enteredVideosList[i]}")
               validVideoIDs = False
               confirm = False
               break
-
         for i in range(len(videoListResult)): # Change this
           if videoListResult[i][0] == True:
-            videosToScan[i]['videoID'] = str(videoListResult[i][1])
-            videosToScan[i]['videoTitle'] = str(videoListResult[i][2])
-            videosToScan[i]['commentCount'] = int(videoListResult[i][3])
-            videosToScan[i]['channelOwnerID'] = str(videoListResult[i][4])
-            videosToScan[i]['channelOwnerName'] = str(videoListResult[i][5])
+            videoDict = {
+              "videoID": str(videoListResult[i][1]),
+              "videoTitle": str(videoListResult[i][2]),
+              "commentCount": int(videoListResult[i][3]),
+              "channelOwnerID": str(videoListResult[i][4]),
+              "channelOwnerName": str(videoListResult[i][5])
+            }
+            if videoDict not in videosToScan:
+              videosToScan.append(videoDict)
             miscData.totalCommentCount += int(videoListResult[i][3])
-            if str(videoListResult[i][1]) not in current.vidTitleDict:
-              current.vidTitleDict[videoListResult[i][1]] = str(videoListResult[i][2])
+            if str(videoDict["videoID"]) not in current.vidTitleDict:
+              current.vidTitleDict[videoDict["videoID"]] = str(videoDict["videoTitle"])
           else:
             print(f"\nInvalid Video: {enteredVideosList[i]}  |  Video ID = {videoListResult[1]}")
             validConfigSetting = False
             break
-          
           # Check each video against first to ensure all on same channel
           if allVideosMatchBool == True:
             misMatchVidIndex = 0
-          if videosToScan[0]['channelOwnerID'] != videosToScan[i]['channelOwnerID']:
+          if videosToScan[0]['channelOwnerID'] != videoDict['channelOwnerID']:
             misMatchVidIndex += 1
             if allVideosMatchBool == True:
               print(f"\n {F.LIGHTRED_EX}ERROR: Videos scanned together all must be from the same channel.{S.R}")
@@ -674,7 +676,7 @@ def main():
           if len(videosToScan) < numVideos:
             print(f"\n{F.YELLOW} WARNING:{S.R} Only {len(videosToScan)} videos found. Videos may be skipped if there are no comments.")
           print("\nRecent Videos To Be Scanned:")
-          for i in range(len(videosToScan)):
+          for i, video in enumerate(videosToScan):
             if config['skip_confirm_video'] == False:
               if i == 10 and len(videosToScan) > 11:
                 remainingCount = str(len(videosToScan) - 10)
@@ -683,7 +685,7 @@ def main():
                   break 
                 elif userChoice == None:
                   return True # Return to main menu         
-            print(f"  {i+1}. {videosToScan[i]['videoTitle']}")
+            print(f"  {i+1}. {video['videoTitle']}")
 
           if config['skip_confirm_video'] == True and validConfigSetting == True:
             confirm = True
@@ -847,9 +849,9 @@ def main():
       print("\n------------------------------------------------------------")
       print(f"Retrieved {F.YELLOW}{len(recentPostsListofDicts)} recent posts{S.R} from {F.LIGHTCYAN_EX}{channelTitle}{S.R}")
       print(f"\n  Post Content Samples:")
-      for i in range(len(recentPostsListofDicts)):
+      for i, post in enumerate(recentPostsListofDicts):
         # recentPostsListofDicts = {post id : post text} - Below prints sample of post text
-        print(f"    {i+1}.".ljust(9, " ") + f"{list(recentPostsListofDicts[i].values())[0][0:50]}")
+        print(f"    {i+1}.".ljust(9, " ") + f"{list(post.values())[0][0:50]}")
 
       if userNotChannelOwner == True:
               print(f"\n > {F.LIGHTRED_EX}Warning:{S.R} You are scanning someone elses post. {F.LIGHTRED_EX}'Not Your Channel Mode'{S.R} Enabled.")

--- a/example_test.txt
+++ b/example_test.txt
@@ -1,5 +1,0 @@
-https://youtube.com/watch?v=ySWYrWoxEho
-https://www.youtube.com/watch?v=M-6H6s40Z4w
-https://www.youtube.com/watch?v=_tqwh-tDfeM
-https://www.youtube.com/watch?v=o5Y29-oo8fo
-https://youtube.com/watch?v=ySWYrWoxEho,https://www.youtube.com/watch?v=M-6H6s40Z4w,https://www.youtube.com/watch?v=_tqwh-tDfeM,https://www.youtube.com/watch?v=o5Y29-oo8fo

--- a/example_test.txt
+++ b/example_test.txt
@@ -1,0 +1,5 @@
+https://youtube.com/watch?v=ySWYrWoxEho
+https://www.youtube.com/watch?v=M-6H6s40Z4w
+https://www.youtube.com/watch?v=_tqwh-tDfeM
+https://www.youtube.com/watch?v=o5Y29-oo8fo
+https://youtube.com/watch?v=ySWYrWoxEho,https://www.youtube.com/watch?v=M-6H6s40Z4w,https://www.youtube.com/watch?v=_tqwh-tDfeM,https://www.youtube.com/watch?v=o5Y29-oo8fo


### PR DESCRIPTION
Adding functions to get uploads in utils.py for less use quota since only requests once.

# Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- While fetching block of videos if will requests playlist ID every single time
- So if requests a lot of videos, if will be requests every time block
- So only requests in once and that it

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Proposed Changes
- Fix operations.py in recent videos retrieve function
- Add functions to utils.py

# Additional Info
- You can fix in official release.

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

# Screenshots

Original | Updated
:----------------------:|:-----------:
no response  | ![Screenshot 2022-04-11 171757](https://user-images.githubusercontent.com/95196459/162720275-c003db44-5d6c-433f-b12b-c5c4b9057186.png)

