### PR TITLE
`apt` > `apt-get`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ install_fail () {
 }
 
 install_debian () {
-    sudo apt install python3 python3-dev python3-tk python3-pip git || install_fail
+    sudo apt-get install python3 python3-dev python3-tk python3-pip git || install_fail
 }
 
 install_fedora () {


### PR DESCRIPTION
### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Replaced `apt` with `apt-get`.

#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Proposed Changes
- Change `apt` to `apt-get`

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It's needed because `apt` has a bad CLI interface for scripts, `apt-get` has a better script CLI. If `apt` is detected as being used in a script, it outputs:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings