### PR TITLE
Redirect all error messages printed by python files to stderr.

### DIFF
--- a/Scripts/auth.py
+++ b/Scripts/auth.py
@@ -47,7 +47,7 @@ def get_authenticated_service():
     if os.path.exists(f"{CLIENT_SECRETS_FILE}.json"):
       CLIENT_SECRETS_FILE = CLIENT_SECRETS_FILE + ".json"
     else:
-      print(f"\n         ----- {F.WHITE}{B.RED}[!] Error:{S.R} client_secrets.json file not found -----")
+      print(f"\n         ----- {F.WHITE}{B.RED}[!] Error:{S.R} client_secrets.json file not found -----", file=sys.stderr)
       print(f" ----- Did you create a {F.YELLOW}Google Cloud Platform Project{S.R} to access the API? ----- ")
       print(f"  > For instructions on how to get an API key, visit: {F.YELLOW}TJoe.io/api-setup{S.R}")
       print(f"\n  > (Non-shortened Link: https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key)")
@@ -81,7 +81,7 @@ def first_authentication():
   try:
     YOUTUBE = get_authenticated_service() # Create authentication object
   except JSONDecodeError as jx:
-    print(f"{F.WHITE}{B.RED} [!!!] Error: {S.R}" + str(jx))
+    print(f"{F.WHITE}{B.RED} [!!!] Error: {S.R}" + str(jx), file=sys.stderr)
     print(f"\nDid you make the client_secrets.json file yourself by {F.LIGHTRED_EX}copying and pasting into it{S.R}, instead of {F.LIGHTGREEN_EX}downloading it{S.R}?")
     print(f"You need to {F.YELLOW}download the json file directly from the Google Cloud dashboard{S.R} as shown in the instructions.")
     print("If you think this is a bug, you may report it on this project's GitHub page: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
@@ -96,9 +96,9 @@ def first_authentication():
       print('\n')
       traceback.print_exc() # Prints traceback
       print("----------------")
-      print(f"{F.RED}[!!!] Error: {S.R}" + str(e))
+      print(f"{F.RED}[!!!] Error: {S.R}" + str(e), file=sys.stderr)
       print("If you think this is a bug, you may report it on this project's GitHub page: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
-      input(f"\nError Code A-1: {F.RED}Something went wrong during authentication.{S.R} {F.YELLOW}Try deleting the token.pickle file.{S.R} \nPress Enter to Exit...")
+      input(f"\nError Code A-1: {F.RED}Something went wrong during authentication.{S.R} {F.YELLOW}Try deleting the token.pickle file.{S.R} \nPress Enter to Exit...", file=sys.stderr)
       sys.exit()
   return YOUTUBE
 
@@ -124,7 +124,7 @@ def get_current_user(config):
   # Catch exceptions if problems getting info
   if len(results) == 0: # Check if results are empty
     print("\n----------------------------------------------------------------------------------------")
-    print(f"{F.YELLOW}Error Getting Current User{S.R}: The YouTube API responded, but did not provide a Channel ID.")
+    print(f"{F.YELLOW}Error Getting Current User{S.R}: The YouTube API responded, but did not provide a Channel ID.", file=sys.stderr)
     print(f"{F.CYAN}Known Possible Causes:{S.R}")
     print("> The client_secrets file does not match user authorized with token.pickle file.")
     print("> You are logging in with a Google Account that does not have a YouTube channel created yet.")
@@ -144,20 +144,20 @@ def get_current_user(config):
     try:
       channelTitle = results["items"][0]["snippet"]["title"] # If channel ID was found, but not channel title/name
     except KeyError:
-      print("Error Getting Current User: Channel ID was found, but channel title was not retrieved. If this occurs again, try deleting 'token.pickle' file and re-running. If that doesn't work, consider filing a bug report on the GitHub project 'issues' page.")
+      print("Error Getting Current User: Channel ID was found, but channel title was not retrieved. If this occurs again, try deleting 'token.pickle' file and re-running. If that doesn't work, consider filing a bug report on the GitHub project 'issues' page.", file=sys.stderr)
       print("> NOTE: The program may still work - You can try continuing. Just check the channel ID is correct: " + str(channelID))
       channelTitle = ""
       input("Press Enter to Continue...")
       pass
   except ChannelIDError:
     traceback.print_exc()
-    print("\nError: Still unable to get channel info. Big Bruh Moment. Try deleting token.pickle. The info above might help if you want to report a bug.")
+    print("\nError: Still unable to get channel info. Big Bruh Moment. Try deleting token.pickle. The info above might help if you want to report a bug.", file=sys.stderr)
     print("Note: A channel ID was retrieved but is invalid: " + str(channelID))
     input("\nPress Enter to Exit...")
     sys.exit()
   except KeyError:
     traceback.print_exc()
-    print("\nError: Still unable to get channel info. Big Bruh Moment. Try deleting token.pickle. The info above might help if you want to report a bug.")
+    print("\nError: Still unable to get channel info. Big Bruh Moment. Try deleting token.pickle. The info above might help if you want to report a bug.", file=sys.stderr)
     input("\nPress Enter to Exit...")
     sys.exit()
   
@@ -169,11 +169,11 @@ def get_current_user(config):
     if config['your_channel_id'] == channelID:
       configMatch = True
     else:
-      print("Error: The channel ID in the config file appears to be valid, but does not match the channel ID of the currently logged in user.")
+      print("Error: The channel ID in the config file appears to be valid, but does not match the channel ID of the currently logged in user.", file=sys.stderr)
       input("Please check the config file. Press Enter to Exit...")
       sys.exit()
   else:
-    print("Error: The channel ID in the config file appears to be invalid.")
+    print("Error: The channel ID in the config file appears to be invalid.", file=sys.stderr)
     input("Please check the config file. Press Enter to Exit...")
     sys.exit()
 

--- a/Scripts/files.py
+++ b/Scripts/files.py
@@ -48,21 +48,21 @@ def check_lists_update(spamListDict, silentCheck = False):
     try:
       os.mkdir(SpamListFolder)
     except:
-      print("Error: Could not create folder. Try creating a folder called 'spam_lists' to update the spam lists.")
+      print("Error: Could not create folder. Try creating a folder called 'spam_lists' to update the spam lists.", file=sys.stderr)
 
   try:
     response = requests.get("https://api.github.com/repos/ThioJoe/YT-Spam-Domains-List/releases/latest")
     if response.status_code != 200:
       if response.status_code == 403:
         if silentCheck == False:
-          print(f"\n{B.RED}{F.WHITE}Error [U-4L]:{S.R} Got an 403 (ratelimit_reached) when attempting to check for spam list update.")
+          print(f"\n{B.RED}{F.WHITE}Error [U-4L]:{S.R} Got a 403 (ratelimit_reached) when attempting to check for spam list update.", file=sys.stderr)
           print(f"This means you have been {F.YELLOW}rate limited by github.com{S.R}. Please try again in a while.\n")
           return False
         else:
           return spamListDict
       else:
         if silentCheck == False:
-          print(f"{B.RED}{F.WHITE}Error [U-3L]:{S.R} Got non 200 status code (got: {response.status_code}) when attempting to check for spam list update.\n")
+          print(f"{B.RED}{F.WHITE}Error [U-3L]:{S.R} Got non 200 status code (got: {response.status_code}) when attempting to check for spam list update.\n", file=sys.stderr)
           print(f"If this keeps happening, you may want to report the issue here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
           if silentCheck == False:
             return False
@@ -74,18 +74,18 @@ def check_lists_update(spamListDict, silentCheck = False):
       return spamListDict
     else:
       if "WinError 10013" in str(ox):
-        print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n")
+        print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n", file=sys.stderr)
         return False
       else:
         print(str(ox))
-        print(f"{B.RED}{F.WHITE}\n Unexpected OS Error {S.R} See error details above.\n")
+        print(f"{B.RED}{F.WHITE}\n Unexpected OS Error {S.R} See error details above.\n", file=sys.stderr)
         return False
         
   except:
     if silentCheck == True:
       return spamListDict
     else:
-      print("Error: Could not get latest release info from GitHub. Please try again later.")
+      print("Error: Could not get latest release info from GitHub. Please try again later.", file=sys.stderr)
       return False
 
   # If update available
@@ -119,7 +119,7 @@ def check_lists_update(spamListDict, silentCheck = False):
             continue
           else:
             traceback.print_exc()
-            print(f"\n> {F.RED}Error:{S.R} The zip file containing the spam lists was downloaded, but there was a problem extracting the files because of a permission error. ")
+            print(f"\n> {F.RED}Error:{S.R} The zip file containing the spam lists was downloaded, but there was a problem extracting the files because of a permission error.", file=sys.stderr)
             print(f"This can happen if an antivirus takes a while to scan the file. You may need to manually extract the zip file.")
             input("\nPress Enter to Continue anyway...")
             break
@@ -130,7 +130,7 @@ def check_lists_update(spamListDict, silentCheck = False):
 
     elif total_size_in_bytes != 0 and os.stat(downloadFilePath).st_size != total_size_in_bytes:
       os.remove(downloadFilePath)
-      print(f" > {F.RED} File did not fully download. Please try again later.{S.R}\n")
+      print(f" > {F.RED} File did not fully download. Please try again later.{S.R}\n", file=sys.stderr)
       return spamListDict
   else:
     update_last_checked()
@@ -176,13 +176,13 @@ def check_for_filter_update(filterListDict, silentCheck = False):
       return False
     else:
       if "WinError 10013" in str(ox):
-        print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n")
+        print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n", file=sys.stderr)
         return False
   except:
     if silentCheck == True:
       return False
     else:
-      print("Error: Could not get latest release info from GitHub. Please try again later.")
+      print("Error: Could not get latest release info from GitHub. Please try again later.", file=sys.stderr)
       return False
 
   if parse_version(localVersion) < parse_version(latestFilterVersion):
@@ -193,7 +193,7 @@ def check_for_filter_update(filterListDict, silentCheck = False):
       copyfile(filterFilePath, os.path.abspath(backupFilePath))
       print(f"\nOld filter file backed up to {backupFilePath}\n")
     except:
-      print(f" > {F.RED}Error:{S.R} Could not create backup of filter_variables.py file. Please check permissions and try again. Or just rename the file manually.")
+      print(f" > {F.RED}Error:{S.R} Could not create backup of filter_variables.py file. Please check permissions and try again. Or just rename the file manually.", file=sys.stderr)
       input("\nPress Enter to Continue With Current Filter Version...")
       return False
     
@@ -216,19 +216,14 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
 
     if response.status_code != 200:
       if response.status_code == 403:
+        print(f"\n{B.RED}{F.WHITE}Error [U-4]:{S.R} Got an 403 (ratelimit_reached) when attempting to check for update.", file=sys.stderr)
         if silentCheck == False:
-          print(f"\n{B.RED}{F.WHITE}Error [U-4]:{S.R} Got an 403 (ratelimit_reached) when attempting to check for update.")
           print(f"This means you have been {F.YELLOW}rate limited by github.com{S.R}. Please try again in a while.\n")
-        else:
-          print(f"\n{B.RED}{F.WHITE}Error [U-4]:{S.R} Got an 403 (ratelimit_reached) when attempting to check for update.")
         return None
-
       else:
+        print(f"{B.RED}{F.WHITE}Error [U-3]:{S.R} Got non 200 status code (got: {response.status_code}) when attempting to check for update.\n", file=sys.stderr)
         if silentCheck == False:
-          print(f"{B.RED}{F.WHITE}Error [U-3]:{S.R} Got non 200 status code (got: {response.status_code}) when attempting to check for update.\n")
           print(f"If this keeps happening, you may want to report the issue here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
-        else:
-          print(f"{B.RED}{F.WHITE}Error [U-3]:{S.R} Got non 200 status code (got: {response.status_code}) when attempting to check for update.\n")
         return None
 
     else:
@@ -255,17 +250,17 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
 
   except OSError as ox:
     if "WinError 10013" in str(ox):
-      print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n")
+      print(f"{B.RED}{F.WHITE}WinError 10013:{S.R} The OS blocked the connection to GitHub. Check your firewall settings.\n", file=sys.stderr)
     else:
-      print(f"{B.RED}{F.WHITE}Unknown OSError{S.R} Error occurred while checking for updates\n")
+      print(f"{B.RED}{F.WHITE}Unknown OSError{S.R} Error occurred while checking for updates\n", file=sys.stderr)
     return None
   except Exception as e:
     if silentCheck == False:
-      print(str(e) + "\n")
-      print(f"{B.RED}{F.WHITE}Error [Code U-1]:{S.R} Problem while checking for updates. See above error for more details.\n")
+      print(str(e) + "\n", file=sys.stderr)
+      print(f"{B.RED}{F.WHITE}Error [Code U-1]:{S.R} Problem while checking for updates. See above error for more details.\n", file=sys.stderr)
       print("If this keeps happening, you may want to report the issue here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
     elif silentCheck == True:
-      print(f"{B.RED}{F.WHITE}Error [Code U-1]:{S.R} Unknown problem while checking for updates. See above error for more details.\n")
+      print(f"{B.RED}{F.WHITE}Error [Code U-1]:{S.R} Unknown problem while checking for updates. See above error for more details.\n", file=sys.stderr)
     return None
 
   if parse_version(latestVersion) > parse_version(currentVersion):
@@ -311,12 +306,12 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
           ignoreHash = False
           # Validate Retrieved Info    
           if j > 1: # More than one exe file in release
-            print(f"{F.YELLOW}Warning!{S.R} Multiple exe files found in release. You must be updating from the future when that was not anticipated.")
+            print(f"{F.YELLOW}Warning!{S.R} Multiple .exe files found in release. You must be updating from the future when that was not anticipated.")
             print("You should instead manually download the latest version from: https://github.com/ThioJoe/YT-Spammer-Purge/releases")
             print("You can try continuing anyway, but it might not be successful, or might download the wrong exe file.")
             input("\nPress Enter to Continue...")
           elif j == 0: # No exe file in release
-            print(f"{F.LIGHTRED_EX}Warning!{S.R} No exe file found in release. You'll have to manually download the latest version from:")
+            print(f"{F.LIGHTRED_EX}Warning!{S.R} No .exe file found in release. You'll have to manually download the latest version from:")
             print("https://github.com/ThioJoe/YT-Spammer-Purge/releases")
             return False
           if k == 0: # No hash file in release
@@ -344,7 +339,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
                 os.remove(downloadFileName)
               except:
                 traceback.print_exc()
-                print(f"\n{F.LIGHTRED_EX}Error F-6:{S.R} Problem deleting existing file! Check if it's gone, or delete it yourself, then try again.")
+                print(f"\n{F.LIGHTRED_EX}Error F-6:{S.R} Problem deleting existing file! Check if it's gone, or delete it yourself, then try again.", file=sys.stderr)
                 print("The info above may help if it's a bug, which you can report here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
                 input("Press Enter to Exit...")
                 sys.exit()
@@ -368,7 +363,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
             print(f"\n> {F.RED} File did not fully download. Please try again later.")
             return False
           elif total_size_in_bytes == 0:
-            print("Something is wrong with the download on the remote end. You should manually download latest version here:")
+            print("Something is wrong with the download on the remote end. You should manually download latest version here:", file=sys.stderr)
             print("https://github.com/ThioJoe/YT-Spammer-Purge/releases")
 
           # Verify hash
@@ -419,7 +414,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
           extraFolderPath = os.listdir(f"./{stagingFolder}")
           # If there happens to be more then one folder
           if(len(extraFolderPath) != 1):
-            print(f"\n> {F.RED} Error:{S.R} more than one folder in {stagingFolder}! Please make a bug report.")
+            print(f"\n> {F.RED} Error:{S.R} more than one folder in {stagingFolder}! Please file a bug report.", file=sys.stderr)
             print(f"\n{F.RED}Aborting Update!{S.R}")
             print("\n> Cleaning up...")
             rmtree(stagingFolder)
@@ -443,7 +438,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
           sys.exit()
 
         else:
-          print(f"> {F.RED} Error:{S.R} You are using an unsupported OS for the autoupdater (macos). \n This updater only supports Windows and Linux (right now). Feel free to get the files from github: https://github.com/ThioJoe/YT-Spammer-Purge")
+          print(f"> {F.RED} Error:{S.R} You are using an unsupported OS for the autoupdater (macos). \n This updater only supports Windows and Linux (right now). Feel free to get the files from github: https://github.com/ThioJoe/YT-Spammer-Purge", file=sys.stderr)
           return False
       elif userChoice == "False" or userChoice == None:
         return False
@@ -471,7 +466,7 @@ def getRemoteFile(url, downloadFilePath, streamChoice=True, silent=False, header
         response = requests.get(url, headers=headers, stream=True)
       if response.status_code != 200:
         if silent == False:
-          print("Error fetching remote file or resource:  " + url)
+          print("Error fetching remote file or resource:  " + url, file=sys.stderr)
           print("Response Code: " + str(response.status_code))
       else:
         return response
@@ -479,7 +474,7 @@ def getRemoteFile(url, downloadFilePath, streamChoice=True, silent=False, header
     except Exception as e:
       if silent == False:
         print(str(e) + "\n")
-        print(f"{B.RED}{F.WHITE} Error {S.R} While Fetching Remote File or Resource: " + url)
+        print(f"{B.RED}{F.WHITE} Error {S.R} While Fetching Remote File or Resource: " + url, file=sys.stderr)
         print("See above messages for details.\n")
         print("If this keeps happening, you may want to report the issue here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
       return None
@@ -497,7 +492,7 @@ def getRemoteFile(url, downloadFilePath, streamChoice=True, silent=False, header
     download_write_to_disk(filedownload)
     return True
   except:
-    print(f"Warning: Error while downloading {description}. Retrying...")
+    print(f"Warning: Error while downloading {description}. Retrying...", file=sys.stderr)
     # Try again with different download method, 'stream' is set to opposite of before
 
     streamChoice = not streamChoice
@@ -508,7 +503,7 @@ def getRemoteFile(url, downloadFilePath, streamChoice=True, silent=False, header
     except Exception as e:
       traceback.print_exc()
       print(str(e))
-      print(f"\n{B.RED}{F.WHITE} Error: {S.R} Error while downloading {description}. See error details above.\n")
+      print(f"\n{B.RED}{F.WHITE} Error: {S.R} Error while downloading {description}. See error details above.\n", file=sys.stderr)
       time.sleep(1)
       return False
 
@@ -545,7 +540,7 @@ def load_config_file(configVersion=None, forceDefault=False, skipConfigChoice=Fa
       configFile.close()
   except:
     traceback.print_exc()
-    print(f"{B.RED}{F.WHITE}Error Code: F-4{S.R} - Config file found, but there was a problem loading it! The info above may help if it's a bug.")
+    print(f"{B.RED}{F.WHITE}Error Code: F-4{S.R} - Config file found, but there was a problem loading it! The info above may help if it's a bug.", file=sys.stderr)
     print("\nYou can manually delete SpamPurgeConfig.ini and use the program to create a new default config.")
     input("Press Enter to Exit...")
     sys.exit()
@@ -593,7 +588,7 @@ def load_config_file(configVersion=None, forceDefault=False, skipConfigChoice=Fa
         configDict = choose_config_file(configDict, configVersion, currentConfigFileNameWithPath)
         
     else:
-      print("Error C-1: Invalid value in config file for setting 'use_this_config' - Must be 'True', 'False', or 'Ask'")
+      print("Error C-1: Invalid value in config file for setting 'use_this_config' - Must be 'True', 'False', or 'Ask'", file=sys.stderr)
       input("Press Enter to Exit...")
       sys.exit()
 
@@ -687,7 +682,7 @@ def check_update_config_file(newVersion, existingConfig, configFileNameWithPath)
           print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{os.path.relpath(configFileNameWithPath)}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
           input("\n Press Enter to Try Again...")
         else:
-          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{os.path.relpath(configFileNameWithPath)}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Updating Config (May Cause Errors)?{S.R} (N)")
+          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{os.path.relpath(configFileNameWithPath)}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Updating Config (May Cause Errors)?{S.R} (N)", file=sys.stderr)
           if choice("Choice:") == False:
             break 
 
@@ -695,7 +690,7 @@ def check_update_config_file(newVersion, existingConfig, configFileNameWithPath)
   except:
     traceback.print_exc()
     print("--------------------------------------------------------------------------------")
-    print("Something went wrong when copying your config settings. You'll have to manually copy them from backup.")
+    print("Something went wrong when copying your config settings. You'll have to manually copy them from backup.", file=sys.stderr)
     input("\nPress Enter to Exit...")
     sys.exit()
   
@@ -743,7 +738,7 @@ def list_config_files(configDict=None, configPath=None):
             else:
               traceback.print_exc()
               print("--------------------------------------------------------------------------------")
-              print("Something went wrong when getting list of config files. Check your regex.")
+              print("Something went wrong when getting list of config files. Check your regex.", file=sys.stderr)
               input("\nPress Enter to Exit...")
               sys.exit()
 
@@ -931,7 +926,7 @@ def create_config_file(updating=False, dontWarn=False, configFileName="SpamPurge
           os.remove(configFileName)
         except:
           traceback.print_exc()
-          print("Error Code F-1: Problem deleting existing file! Check if it's gone. The info above may help if it's a bug.")
+          print("Error Code F-1: Problem deleting existing file! Check if it's gone. The info above may help if it's a bug.", file=sys.stderr)
           print("If this keeps happening, you may want to report the issue here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
           input("Press Enter to Exit...")
           sys.exit()
@@ -948,7 +943,7 @@ def create_config_file(updating=False, dontWarn=False, configFileName="SpamPurge
     defaultConfigFile.close()
   except:
     traceback.print_exc()
-    print(f"{B.RED}{F.WHITE}Error Code: F-2{S.R} - Problem reading default config file! The info above may help if it's a bug.")
+    print(f"{B.RED}{F.WHITE}Error Code: F-2{S.R} - Problem reading default config file! The info above may help if it's a bug.", file=sys.stderr)
     input("Press Enter to Exit...")
     sys.exit()
 
@@ -976,15 +971,15 @@ def create_config_file(updating=False, dontWarn=False, configFileName="SpamPurge
       success = True
     except PermissionError:
       if attempts < 3:
-        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{configFileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{configFileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
         input("\n Press Enter to Try Again...")
       else:
-        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{configFileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Abandon Writing Config?{S.R} (N)")
+        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{configFileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Abandon Writing Config?{S.R} (N)", file=sys.stderr)
         if choice("Choice:") == False:
           break 
     except:
       traceback.print_exc()
-      print(f"{B.RED}{F.WHITE}Error Code: F-3{S.R} Problem creating config file! The info above may help if it's a bug.")
+      print(f"{B.RED}{F.WHITE}Error Code: F-3{S.R} Problem creating config file! The info above may help if it's a bug.", file=sys.stderr)
       input("Press Enter to Exit...")
       sys.exit()
 
@@ -1066,9 +1061,9 @@ def parse_comment_list(config, recovery=False, removal=False, returnFileName=Fal
           listFile.close()
           validFile = True
         except:
-          print(f"{F.RED}Error Code F-5:{S.R} Log File was found but there was a problem reading it.")
+          print(f"{F.RED}Error Code F-5:{S.R} Log File was found but there was a problem reading it.", file=sys.stderr)
       else:
-        print(f"\n{F.LIGHTRED_EX}Error: File not found.{S.R} Make sure it is in the same folder as the program.\n")
+        print(f"\n{F.LIGHTRED_EX}Error: File not found.{S.R} Make sure it is in the same folder as the program.\n", file=sys.stderr)
         print(f"Enter '{F.YELLOW}Y{S.R}' to try again, or '{F.YELLOW}N{S.R}' to manually paste in the comment IDs.")
         userChoice = choice("Try entering file name again?")
         if userChoice == True:
@@ -1103,7 +1098,7 @@ def parse_comment_list(config, recovery=False, removal=False, returnFileName=Fal
   resultList = resultList.split(",")
 
   if len(resultList) == 0:
-    print(f"\n{F.RED}Error Code R-1:{S.R} No comment IDs detected, try entering them manually and make sure they are formatted correctly.")
+    print(f"\n{F.RED}Error Code R-1:{S.R} No comment IDs detected, try entering them manually and make sure they are formatted correctly.", file=sys.stderr)
     input("\nPress Enter to return to main menu...")
     return "MainMenu", None
 
@@ -1153,7 +1148,7 @@ def write_dict_pickle_file(dictToWrite, fileName, relativeFolderPath=RESOURCES_F
         os.mkdir(relativeFolderPath)
         success = True
       except:
-        print(f"Error: Could not create folder. Try creating the folder {relativeFolderPath} to continue.")
+        print(f"Error: Could not create folder. Try creating the folder {relativeFolderPath} to continue.", file=sys.stderr)
         input("Press Enter to try again...")
 
   if os.path.exists(fileNameWithPath):
@@ -1203,13 +1198,13 @@ def read_dict_pickle_file(fileNameNoPath, relativeFolderPath=RESOURCES_FOLDER_NA
         except:
           traceback.print_exc()
           print("--------------------------------------------------------------------------------")
-          print("Something went wrong when reading your pickle file. Is it in use? Try closing it.")
+          print("Something went wrong when reading your pickle file. Is it in use? Try closing it.", file=sys.stderr)
           input(f"\nPress Enter to try loading file again: {fileNameWithPath}")
           failedAttemptCount += 1
       return False
 
     else:
-      print(f"\nFile '{fileNameNoPath}' not found! Try entering the name manually.")
+      print(f"\nFile '{fileNameNoPath}' not found! Try entering the name manually.", file=sys.stderr)
       input(f"\nPress Enter to try loading file again: {fileNameWithPath}")
       failedAttemptCount += 1
 
@@ -1223,10 +1218,10 @@ def try_remove_file(fileNameWithPath):
       os.remove(fileNameWithPath)
       return True
     except:
-      print(f"\n{F.RED}\nERROR:{S.R} Could not remove file: '{fileNameWithPath}'. Is it open? If so, try closing it.")
+      print(f"\n{F.RED}\nERROR:{S.R} Could not remove file: '{fileNameWithPath}'. Is it open? If so, try closing it.", file=sys.stderr)
       input("\nPress Enter to try again...")
       attempts += 1
-  print(f"\n{F.RED}\nERROR:{S.R} The File '{fileNameWithPath}' still could not be removed. You may have to delete it yourself.")
+  print(f"\n{F.RED}\nERROR:{S.R} The File '{fileNameWithPath}' still could not be removed. You may have to delete it yourself.", file=sys.stderr)
   input("\nPress Enter to Continue...")
   return False
 

--- a/Scripts/logging.py
+++ b/Scripts/logging.py
@@ -425,7 +425,7 @@ def write_rtf(fileName, newText=None, firstWrite=False, fullWrite=False):
         if not os.path.isabs(fileName):
           fileName = os.path.join(logFolderPath, os.path.basename(fileName))
       except:
-        print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.")
+        print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.", file=sys.stderr)
         fileName = os.path.basename(fileName)
     while success == False:
       try:
@@ -445,10 +445,10 @@ def write_rtf(fileName, newText=None, firstWrite=False, fullWrite=False):
         success = True
       except PermissionError:
         if attempts < 3:
-          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
           input("\n Press Enter to Try Again...")
         else:
-          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)")
+          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)", file=sys.stderr)
           if choice("Choice") == False:
             break
 
@@ -477,10 +477,10 @@ def write_rtf(fileName, newText=None, firstWrite=False, fullWrite=False):
           success = True
       except PermissionError:
         if attempts < 3:
-          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
           input("\n Press Enter to Try Again...")
         else:
-          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)")
+          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)", file=sys.stderr)
           if choice("Choice") == False:
             break
 
@@ -499,7 +499,7 @@ def write_plaintext_log(fileName, newText=None, firstWrite=False, fullWrite=Fals
         if not os.path.isabs(fileName):
           fileName = os.path.join(logFolderPath, os.path.basename(fileName))
       except:
-        print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.")
+        print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.", file=sys.stderr)
         fileName = os.path.basename(fileName)
     while success == False:
       try:
@@ -513,10 +513,10 @@ def write_plaintext_log(fileName, newText=None, firstWrite=False, fullWrite=Fals
         success = True
       except PermissionError:
         if attempts < 3:
-          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
           input("\n Press Enter to Try Again...")
         else:
-          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)")
+          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)", file=sys.stderr)
           if choice("Choice") == False:
             break 
 
@@ -531,10 +531,10 @@ def write_plaintext_log(fileName, newText=None, firstWrite=False, fullWrite=Fals
         success = True
       except PermissionError:
         if attempts < 3:
-          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+          print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
           input("\n Press Enter to Try Again...")
         else:
-          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)")
+          print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)", file=sys.stderr)
           if choice("Choice") == False:
             break 
 
@@ -570,7 +570,7 @@ def write_json_log(current, config, jsonSettingsDict, commentsDict, jsonDataDict
       if not os.path.isabs(fileName):
         fileName = os.path.join(logFolderPath, os.path.basename(fileName))
     except:
-      print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.")
+      print(f"{F.LIGHTRED_EX}Error:{S.R} Could not create desired directory for log files. Will place them in current directory.", file=sys.stderr)
       fileName = os.path.basename(fileName)
   while success == False:
     try:
@@ -589,10 +589,10 @@ def write_json_log(current, config, jsonSettingsDict, commentsDict, jsonDataDict
       success = True
     except PermissionError:
       if attempts < 3:
-        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
         input("\n Press Enter to Try Again...")
       else:
-        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)")
+        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Writing Log?{S.R} (N)", file=sys.stderr)
         if choice("Choice") == False:
           break 
 
@@ -643,7 +643,7 @@ def get_extra_json_data(channelIDs, jsonSettingsDict):
           jsonExtraDataDict['CommentAuthorInfo'][channelID] = tempDict
     except:
       traceback.print_exc()
-      print("Error occurred when fetching extra JSON data.")
+      print("Error occurred when fetching extra JSON data.", file=sys.stderr)
       return False
 
   # Get Extra Info About Commenters
@@ -693,7 +693,7 @@ def download_profile_pictures(pictureUrlsDict, jsonSettingsDict):
     try:
       os.mkdir(imageFolderPath)
     except:
-      print(f"{F.LIGHTRED_EX}Error:{S.R} Unable to create image folder. Try creating a folder called 'ProfileImages' in the log file folder.")
+      print(f"{F.LIGHTRED_EX}Error:{S.R} Unable to create image folder. Try creating a folder called 'ProfileImages' in the log file folder.", file=sys.stderr)
       return False, None
 
   attempts = 0
@@ -715,10 +715,10 @@ def download_profile_pictures(pictureUrlsDict, jsonSettingsDict):
       print("Successfully downloaded profile pictures.")
     except PermissionError:
       if attempts < 3:
-        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.")
+        print(f"\n{F.YELLOW}\nERROR!{S.R} Cannot write to {F.LIGHTCYAN_EX}{fileName}{S.R}. Is it open? Try {F.YELLOW}closing the file{S.R} before continuing.", file=sys.stderr)
         input("\n Press Enter to Try Again...")
       else:
-        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Downloading Profile Pictures?{S.R} (N)")
+        print(f"{F.LIGHTRED_EX}\nERROR! Still cannot write to {F.LIGHTCYAN_EX}{fileName}{F.LIGHTRED_EX}. {F.YELLOW}Try again?{S.R} (Y) or {F.YELLOW}Skip Downloading Profile Pictures?{S.R} (N)", file=sys.stderr)
         if choice("Choice") == False:
           break 
 
@@ -821,7 +821,7 @@ def prepare_logFile_settings(current, config, miscData, jsonSettingsDict, filter
   elif logMode == "plaintext":
     logFileType = ".txt"
   else:
-    print("Invalid value for 'log_mode' in config file:  " + logMode)
+    print("Invalid value for 'log_mode' in config file:  " + logMode, file=sys.stderr)
     print("Defaulting to .rtf file")
     logMode = "rtf"
 
@@ -859,7 +859,7 @@ def prepare_logFile_settings(current, config, miscData, jsonSettingsDict, filter
       jsonSettingsDict['json_profile_picture'] = False
 
   except KeyError:
-    print("Problem getting JSON settings, is your config file correct?")
+    print("Problem getting JSON settings, is your config file correct?", file=sys.stderr)
 
   # Set where to put log files
   defaultLogPath = "logs"

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -589,7 +589,7 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
   minimum_duplicates = int(config['minimum_duplicates'])
   if minimum_duplicates < 2:
     minimum_duplicates = 4
-    print("\nError: minimum_duplicates config setting must be greater than 1. Defaulting to 8.")
+    print("\nError: minimum_duplicates config setting must be greater than 1. Defaulting to 8.", file=sys.stderr)
     input("\nPress Enter to Continue...")
   
   # Get minimum duplicate length setting - Does not need to be validated as int here, because that happens at beginning of program
@@ -658,11 +658,11 @@ def check_reposts(current, config, miscData, allVideoCommentsDict, videoID):
     try:
       levenshtein = float(config['levenshtein_distance'])
       if levenshtein < 0 or levenshtein > 1:
-        print("\nError: Levenshtein_distance config setting must be between 0 and 1. Defaulting to 0.9")
+        print("\nError: Levenshtein_distance config setting must be between 0 and 1. Defaulting to 0.9", file=sys.stderr)
         input("\nPress Enter to Continue...")
         levenshtein = 0.9
     except ValueError:
-      print("\nError: Levenshtein_distance config setting must be a number between 0 and 1. Defaulting to 0.9")
+      print("\nError: Levenshtein_distance config setting must be a number between 0 and 1. Defaulting to 0.9", file=sys.stderr)
       input("\nPress Enter to Continue...")
       levenshtein = 0.9
     fuzzy = True
@@ -674,11 +674,11 @@ def check_reposts(current, config, miscData, allVideoCommentsDict, videoID):
     minLength = int(config['stolen_minimum_text_length'])
     if minLength < 1:
       minLength = 25
-      print("\nError: stolen_minimum_text_length config setting must be greater than 0. Defaulting to 25.")
+      print("\nError: stolen_minimum_text_length config setting must be greater than 0. Defaulting to 25.", file=sys.stderr)
       input("\nPress Enter to Continue...")
   except ValueError:
     minLength = 25
-    print("\nError: stolen_minimum_text_length config setting is invalid. Defaulting to 25.")
+    print("\nError: stolen_minimum_text_length config setting is invalid. Defaulting to 25.", file=sys.stderr)
     input("\nPress Enter to Continue...")
 
   flatCommentList = []
@@ -1093,11 +1093,11 @@ def delete_found_comments(commentsList, banChoice, deletionMode, recoveryMode=Fa
         if len(response) > 0:
           failedComments += commentIDs
       except HttpError:
-        print("\nSomething has gone wrong when removing some comments...")
+        print("\nSomething has gone wrong when removing some comments...", file=sys.stderr)
         failedComments += commentIDs
 
     else:
-      print("Invalid deletion mode. This is definitely a bug, please report it here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
+      print("Invalid deletion mode. This is definitely a bug, please report it here: https://github.com/ThioJoe/YT-Spammer-Purge/issues", file=sys.stderr)
       print("Deletion Mode Is: " + deletionMode)
       input("Press Enter to Exit...")
       sys.exit()
@@ -1210,7 +1210,7 @@ def check_deleted_comments(commentInput):
     elif i > 0:
       print("\n\nWarning: " + str(i) + " comments may remain. Check links above or try running the program again. An error log file has been created: 'Deletion_Error_Log.txt'")
     else:
-      print("\n\nSomething strange happened... The comments may or may have not been deleted.")
+      print("\n\nSomething strange happened... The comments may or may have not been deleted.", file=sys.stderr)
 
     return None
 
@@ -1358,7 +1358,7 @@ def exclude_authors(current, config, miscData, excludedCommentsDict, authorsToEx
   # Verify removal
   for comment in current.matchedCommentsDict.keys():
     if comment in commentIDExcludeSet:
-      print(f"{F.LIGHTRED_EX}FATAL ERROR{S.R}: Something went wrong while trying to exclude comments. No comments have been deleted.")
+      print(f"{F.LIGHTRED_EX}FATAL ERROR{S.R}: Something went wrong while trying to exclude comments. No comments have been deleted.", file=sys.stderr)
       print(f"You should {F.YELLOW}DEFINITELY{S.R} report this bug here: https://github.com/ThioJoe/YT-Spammer-Purge/issues")
       print("Provide the error code: X-1")
       input("Press Enter to Exit...")

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -171,13 +171,13 @@ def choice(message="", bypass=False):
 def print_exception_reason(reason):
   print("    Reason: " + str(reason))
   if reason == "processingFailure":
-    print(f"\n {F.LIGHTRED_EX}[!!] Processing Error{S.R} - Sometimes this error fixes itself. Try just running the program again. !!")
+    print(f"\n {F.LIGHTRED_EX}[!!] Processing Error{S.R} - Sometimes this error fixes itself. Try just running the program again. !!", file=sys.stderr)
     print("This issue is often on YouTube's side, so if it keeps happening try again later.")
     print("(This also occurs if you try deleting comments on someone else's video, which is not possible.)")
   elif reason == "commentsDisabled":
-    print(f"\n{F.LIGHTRED_EX}[!] Error:{S.R} Comments are disabled on this video. This error can also occur if scanning a live stream.")
+    print(f"\n{F.LIGHTRED_EX}[!] Error:{S.R} Comments are disabled on this video. This error can also occur if scanning a live stream.", file=sys.stderr)
   elif reason == "quotaExceeded":
-    print(f"\n{F.LIGHTRED_EX}Error:{S.R} You have exceeded the YouTube API quota. To do more scanning you must wait until the quota resets.")
+    print(f"\n{F.LIGHTRED_EX}Error:{S.R} You have exceeded the YouTube API quota. To do more scanning you must wait until the quota resets.", file=sys.stderr)
     print(" > There is a daily limit of 10,000 units/day, which works out to around reporting 10,000 comments/day.")
     print(" > You can check your quota by searching 'quota' in the Google Cloud console.")
     print(f"{F.YELLOW}Solutions: Either wait until tomorrow, or create additional projects in the cloud console.{S.R}")
@@ -185,7 +185,7 @@ def print_exception_reason(reason):
 
 def print_http_error_during_scan(hx):
   print("------------------------------------------------")
-  print(f"{B.RED}{F.WHITE} ERROR! {S.R}  Error Message: " + str(hx))
+  print(f"{B.RED}{F.WHITE} ERROR! {S.R}  Error Message: " + str(hx), file=sys.stderr)
   if hx.status_code:
     print("Status Code: " + str(hx.status_code))
     if hx.error_details[0]["reason"]: # If error reason is available, print it
@@ -194,11 +194,11 @@ def print_http_error_during_scan(hx):
 
 def print_exception_during_scan(ex):
   print("------------------------------------------------")
-  print(f"{B.RED}{F.WHITE} ERROR! {S.R}  Error Message: " + str(ex))
+  print(f"{B.RED}{F.WHITE} ERROR! {S.R}  Error Message: " + str(ex), file=sys.stderr)
 
 def print_break_finished(scanMode):
   print("------------------------------------------------")
-  print(f"\n{F.LIGHTRED_EX}[!] Fatal Error Occurred During Scan! {F.BLACK}{B.LIGHTRED_EX} Read the important info below! {S.R}")
+  print(f"\n{F.LIGHTRED_EX}[!] Fatal Error Occurred During Scan! {F.BLACK}{B.LIGHTRED_EX} Read the important info below! {S.R}", file=sys.stderr)
   print(f"\nProgram must skip the rest of the scan. {F.LIGHTGREEN_EX}Comments already scanned can still be used to create a log file (if you choose){S.R}")
   print(f"  > You won't be able to delete/hide any comments like usual, but you can {F.LIGHTMAGENTA_EX}exclude users before saving the log file{S.R}")
   print(f"  > Then, you can {F.LIGHTGREEN_EX}delete the comments later{S.R} using the {F.YELLOW}mode that removes comments using a pre-existing list{S.R}")
@@ -208,7 +208,7 @@ def print_break_finished(scanMode):
 
 def print_error_title_fetch():
   print("--------------------------------------------------------------------------------------------------------------------------")
-  print(f"\n{F.BLACK}{B.RED} ERROR OCCURRED {S.R} While Fetching Video Title... {F.BLACK}{B.LIGHTRED_EX} READ THE INFO BELOW {S.R}")
+  print(f"\n{F.BLACK}{B.RED} ERROR OCCURRED {S.R} While Fetching Video Title... {F.BLACK}{B.LIGHTRED_EX} READ THE INFO BELOW {S.R}", file=sys.stderr)
   print(f"Program will {F.LIGHTGREEN_EX}attempt to continue{S.R}, but the {F.YELLOW}video title may not be available{S.R} in the log file.")
   print(f"  > You won't be able to delete/hide any comments like usual, but you can {F.LIGHTMAGENTA_EX}exclude users before saving the log file{S.R}")
   print(f"  > Then, you can {F.LIGHTGREEN_EX}delete the comments later{S.R} using the {F.YELLOW}mode that removes comments using a pre-existing log file{S.R}")

--- a/Scripts/validation.py
+++ b/Scripts/validation.py
@@ -40,7 +40,7 @@ def validate_video_id(video_url_or_id, silent=False, pass_exception=False, basic
 
         # Checks if video exists but is unavailable
         if result['items'] == []:
-          print(f"\n{B.RED}{F.WHITE} ERROR: {S.R} {F.RED}No info returned for ID: {S.R} {possibleVideoID} {F.LIGHTRED_EX} - Video may be unavailable or deleted.{S.R}")
+          print(f"\n{B.RED}{F.WHITE} ERROR: {S.R} {F.RED}No info returned for ID: {S.R} {possibleVideoID} {F.LIGHTRED_EX} - Video may be unavailable or deleted.{S.R}", file=sys.stderr)
           return False, None, None, None, None
 
         if possibleVideoID == result['items'][0]['id']:
@@ -57,8 +57,8 @@ def validate_video_id(video_url_or_id, silent=False, pass_exception=False, basic
 
             traceback.print_exc()
             print("--------------------------------------")
-            print(f"\n{B.RED}{F.WHITE} ERROR: {S.R} {F.RED}Unable to get comment count for video: {S.R} {possibleVideoID}  |  {videoTitle}")
-            print(f"\n{F.YELLOW}Are comments disabled on this video?{S.R} If not, please report the bug and include the error info above.")
+            print(f"\n{B.RED}{F.WHITE} ERROR: {S.R} {F.RED}Unable to get comment count for video: {S.R} {possibleVideoID}  |  {videoTitle}", file=sys.stderr)
+            print(f"\n{F.YELLOW}Are comments disabled on this video?{S.R} If not, please report the bug and include the error info above.", file=sys.stderr)
             print(f"                    Bug Report Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
             input("\nPress Enter to return to the main menu...")
             return "MainMenu", "MainMenu", "MainMenu", "MainMenu", "MainMenu"
@@ -185,7 +185,7 @@ def validate_channel_id(inputted_channel):
         print(f"\n{F.LIGHTRED_EX}No Channel Found!{S.R} YouTube returned no results for that channel. Double check it is correct, or try entering the Channel ID.")
         return False, None, None
     else:
-      print(f"\n{B.RED}{F.BLACK}Error:{S.R} You appear to have entered an invalid handle! It must be between 3 and 30 characters long and only contain letters, numbers, periods, underscores, and hyphens.")
+      print(f"\n{B.RED}{F.BLACK}Error:{S.R} You appear to have entered an invalid handle! It must be between 3 and 30 characters long and only contain letters, numbers, periods, underscores, and hyphens.", file=sys.stderr)
       return False, None, None
 
 
@@ -194,7 +194,7 @@ def validate_channel_id(inputted_channel):
     isolatedChannelID = inputted_channel
 
   else:
-    print(f"\n{B.RED}{F.BLACK}Error:{S.R} Invalid Channel link or ID!")
+    print(f"\n{B.RED}{F.BLACK}Error:{S.R} Invalid Channel link or ID!", file=sys.stderr)
     return False, None, None
 
   if len(isolatedChannelID) == 24 and isolatedChannelID[0:2] == "UC":
@@ -203,11 +203,11 @@ def validate_channel_id(inputted_channel):
       channelTitle = response['items'][0]['snippet']['title']
       return True, isolatedChannelID, channelTitle
     else:
-      print(f"{F.LIGHTRED_EX}Error{S.R}: Unable to Get Channel Title. Please check the channel ID.")
+      print(f"{F.LIGHTRED_EX}Error{S.R}: Unable to Get Channel Title. Please check the channel ID.", file=sys.stderr)
       return False, None, None
 
   else:
-    print(f"\n{B.RED}{F.BLACK}Invalid Channel link or ID!{S.R} Channel IDs are 24 characters long and begin with 'UC'.")
+    print(f"\n{B.RED}{F.BLACK}Invalid Channel link or ID!{S.R} Channel IDs are 24 characters long and begin with 'UC'.", file=sys.stderr)
     return False, None, None
 
 ############################ Validate Regex Input #############################
@@ -244,7 +244,7 @@ def validate_config_settings(config):
     sys.exit()
 
   def print_int_fail(setting, value):
-    print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}")
+    print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}", file=sys.stderr)
     print("It must be a whole number greater than zero, or another possible value listed in the config for that setting.")
     print_quit_and_report()
 
@@ -262,19 +262,19 @@ def validate_config_settings(config):
           settingList = utils.string_to_list(value)
           for settingValue in settingList:
             if settingValue not in validSettingsDict[setting]:
-              print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}")
+              print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}", file=sys.stderr)
               print(f"It looks like you tried to enter a list. Check if that setting accepts multiple values or if you entered an invalid value.")
               print_quit_and_report()
           return True
         except:
-          print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}")
+          print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}", file=sys.stderr)
           print("It looks like you tried to enter a list. Check if that setting accepts multiple values or if you entered an invalid value.")
           print_quit_and_report()
 
       elif value in validSettingsDict[setting]:
         return True
       else:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{setting}': {str(value)}", file=sys.stderr)
         print("Check the config file to see valid possible values for that setting.")
         print_quit_and_report()
     else:
@@ -286,11 +286,11 @@ def validate_config_settings(config):
       if value >= 0.0 and value <= 1.0:
         return True
       else:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'levenshtein_distance': {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'levenshtein_distance': {str(value)}", file=sys.stderr)
         print("It must be a number from 0 to 1!")
         print_quit_and_report()
     except:  
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'levenshtein_distance': {str(value)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'levenshtein_distance': {str(value)}", file=sys.stderr)
       print("It must be a number from 0 to 1!")
       print_quit_and_report()
 
@@ -302,7 +302,7 @@ def validate_config_settings(config):
     elif os.path.isdir(path):
       return True
     else:
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{settingName}': {str(path)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting '{settingName}': {str(path)}", file=sys.stderr)
       print("Make sure the folder exists!")
       print_quit_and_report()
   
@@ -311,7 +311,7 @@ def validate_config_settings(config):
       codecs.lookup(value)
       return True
     except LookupError:
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'json_encoding': {str(value)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'json_encoding': {str(value)}", file=sys.stderr)
       print("Make sure the encoding is valid!")
       print_quit_and_report()
 
@@ -322,17 +322,17 @@ def validate_config_settings(config):
       try:
         videoList = utils.string_to_list(value)
       except:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'videos_to_scan': {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'videos_to_scan': {str(value)}", file=sys.stderr)
         print("Make sure it is either a single video ID / Link, or a comma separated list of them!")
         print_quit_and_report()
       if len(videoList) > 0:
         for video in videoList:
           if not validate_video_id(video, basicCheck=True):
-            print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} There appears to be an invalid video ID or Link in setting 'videos_to_scan': {str(value)}")
+            print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} There appears to be an invalid video ID or Link in setting 'videos_to_scan': {str(value)}", file=sys.stderr)
             print_quit_and_report()
         return True
       else:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'videos_to_scan' (it may be empty!): {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'videos_to_scan' (it may be empty!): {str(value)}", file=sys.stderr)
         print("Make sure it is either a single video ID / Link, or a comma separated list of them!")
         print_quit_and_report()
 
@@ -342,7 +342,7 @@ def validate_config_settings(config):
     else:
       result, channelID, channelName = validate_channel_id(value)
       if result == False:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Config setting for 'channel_to_scan' appears invalid: {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Config setting for 'channel_to_scan' appears invalid: {str(value)}", file=sys.stderr)
         print("Make sure it is either a single channel ID or channel link.  If it's a link, try using the channel ID instead.")
         print_quit_and_report()
       else:
@@ -355,12 +355,12 @@ def validate_config_settings(config):
       try:
         channelList = utils.string_to_list(value)
       except:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'channel_ids_to_filter': {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'channel_ids_to_filter': {str(value)}", file=sys.stderr)
         print("Make sure it is either a single channel ID / Link, or a comma separated list of them!")
         print_quit_and_report()
       for channel in channelList:
         if len(channel) != 24 or channel[0:2] != "UC":
-          print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} There appears to be an invalid channel ID in setting 'channel_ids_to_filter': {str(value)}")
+          print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} There appears to be an invalid channel ID in setting 'channel_ids_to_filter': {str(value)}", file=sys.stderr)
           print("A channel ID must be 24 characters long and begin with 'UC'!")
           print_quit_and_report()
       return True
@@ -372,7 +372,7 @@ def validate_config_settings(config):
     if result:
       return True
     else:
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'characters_to_filter': {str(value)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'characters_to_filter': {str(value)}", file=sys.stderr)
       print("For this mode, numbers, letters, and punctuation are removed. But there were no characters left to search!")
       print_quit_and_report()
 
@@ -384,11 +384,11 @@ def validate_config_settings(config):
       if len(result) > 0:
         return True
       else:
-        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'strings_to_filter': {str(value)}")
+        print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'strings_to_filter': {str(value)}", file=sys.stderr)
         print("The list appears empty! Make sure it is either a single string, or a comma separated list of them!")
         print_quit_and_report()
     except:
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'strings_to_filter': {str(value)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} Invalid value for config setting 'strings_to_filter': {str(value)}", file=sys.stderr)
       print("Make sure it is either a single string, or a comma separated list of them!")
       print_quit_and_report()
   
@@ -399,7 +399,7 @@ def validate_config_settings(config):
     if isValid:
       return True
     else:
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R}The config setting 'regex_to_filter' does not appear to be valid: {str(value)}")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R}The config setting 'regex_to_filter' does not appear to be valid: {str(value)}", file=sys.stderr)
       print("Make sure it is a valid regular expression! Example:  [^\x00-\xFF]")
       print("You can test them out on websites like regex101.com")
       print_quit_and_report()
@@ -477,7 +477,7 @@ def validate_config_settings(config):
   # Checks all settings in the config file to ensure they are valid
   for settingName, settingValue in config.items():
     if settingValue == None or settingValue == '':
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} The config setting '{settingName}' appears empty!")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} The config setting '{settingName}' appears empty!", file=sys.stderr)
       print("Please go and add a valid setting value!")
       print_quit_and_report()
 
@@ -526,7 +526,7 @@ def validate_config_settings(config):
 
   for settingName in allSettingsDict:
     if settingName not in list(config.keys()):
-      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} The config setting '{settingName}' is missing from the config file!")
+      print(f"\n{B.RED}{F.WHITE} ERROR! {S.R} The config setting '{settingName}' is missing from the config file!", file=sys.stderr)
       print(" > Did you remove it or are you using an old config file? (It should have auto-updated)")
       print(" > You may need to delete and regenerate the config file.")
       print_quit_and_report()

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -86,7 +86,7 @@ def main():
 
   # Run check on python version, must be 3.6 or higher because of f strings
   if sys.version_info[0] < 3 or sys.version_info[1] < 6:
-    print("Error Code U-2: This program requires running python 3.6 or higher! You are running" + str(sys.version_info[0]) + "." + str(sys.version_info[1]))
+    print("Error Code U-2: This program requires running python 3.6 or higher! You are running" + str(sys.version_info[0]) + "." + str(sys.version_info[1]), file=sys.stderr)
     input("Press Enter to Exit...")
     sys.exit()
 
@@ -154,7 +154,7 @@ def main():
         f.write("# new location they will be stored.\n")
 
     except:
-      print("\nError: Could not create folder. To update the spam lists, try creating a folder called 'SpamPurge_Resources',")
+      print("\nError: Could not create folder. To update the spam lists, try creating a folder called 'SpamPurge_Resources',", file=sys.stderr)
       print("       then inside that, create another folder called 'Spam_Lists'.")
       input("Press Enter to Continue...")
 
@@ -162,15 +162,15 @@ def main():
     try:
       os.mkdir(spamListFolder)
     except:
-      print("\nError: Could not create folder. To update the spam lists, go into the 'SpamPurge_Resources' folder,")
-      print("       then inside that, create another folder called 'Spam_Lists'.")
+      print("\nError: Could not create folder. To update the spam lists, go into the 'SpamPurge_Resources' folder,", file=sys.stderr)
+      print("       then inside that, create another folder called 'Spam_Lists'.", file=sys.stderr)
 
   if os.path.isdir(resourceFolder) and not os.path.isdir(filtersFolder):
       try:
         os.mkdir(filtersFolder)
       except:
-        print("\nError: Could not create folder. To update the spam lists, go into the 'SpamPurge_Resources' folder,")
-        print("       then inside that, create another folder called 'Filters'.")
+        print("\nError: Could not create folder. To update the spam lists, go into the 'SpamPurge_Resources' folder,", file=sys.stderr)
+        print("       then inside that, create another folder called 'Filters'.", file=sys.stderr)
 
   # Prepare to check and ingest spammer list files
   # Iterate and get paths of each list. Also gets path of filter_variables.py
@@ -248,7 +248,7 @@ def main():
     try:
       updateAvailable = files.check_for_update(version, updateReleaseChannel, silentCheck=True, )
     except Exception as e:
-      print(f"{F.LIGHTRED_EX}Error Code U-3 occurred while checking for updates. (Checking can be disabled using the config file setting) Continuing...{S.R}\n")
+      print(f"{F.LIGHTRED_EX}Error Code U-3 occurred while checking for updates. (Checking can be disabled using the config file setting) Continuing...{S.R}\n", file=sys.stderr)
       updateAvailable = None
 
     # Only check for updates once a day, compare current date to last checked date
@@ -418,7 +418,7 @@ def main():
           updateString = f"{B.LIGHTCYAN_EX}{F.BLACK} Beta {S.R}"
       elif updateAvailable == None:
         updateString = f"{F.LIGHTRED_EX}Error{S.R}"
-        print("> Note: Error during check for updates. Select 'Check For Updates' for details.")
+        print("> Note: Error during check for updates. Select 'Check For Updates' for details.", file=sys.stderr)
 
     else:
       if config['auto_check_update'] == False:
@@ -508,7 +508,7 @@ def main():
             if len(enteredVideosList) == 0:
               validConfigSetting = False
               listNotEmpty = False
-              print(f"{F.LIGHTRED_EX}\nError: Video list is empty!{S.R}")
+              print(f"{F.LIGHTRED_EX}\nError: Video list is empty!{S.R}", file=sys.stderr)
             else:
               listNotEmpty = True
           else:
@@ -520,7 +520,7 @@ def main():
             validConfigSetting = False
             if len(enteredVideosList) == 0:
               listNotEmpty = False
-              print(f"{F.LIGHTRED_EX}\nError: Video list is empty!{S.R}")
+              print(f"{F.LIGHTRED_EX}\nError: Video list is empty!{S.R}", file=sys.stderr)
             else:
               listNotEmpty = True
 
@@ -559,7 +559,7 @@ def main():
           if videosToScan[0]['channelOwnerID'] != videosToScan[i]['channelOwnerID']:
             misMatchVidIndex += 1
             if allVideosMatchBool == True:
-              print(f"\n {F.LIGHTRED_EX}ERROR: Videos scanned together all must be from the same channel.{S.R}")
+              print(f"\n {F.LIGHTRED_EX}ERROR: Videos scanned together all must be from the same channel.{S.R}", file=sys.stderr)
               print("  The following videos do not match the channel owner of the first video in the list: ")
             if misMatchVidIndex == 11 and len(enteredVideosList) > 10:
               remainingCount = str(len(enteredVideosList) - 10)
@@ -678,11 +678,11 @@ def main():
             validEntry = True
             validConfigSetting = True
           else:
-            print("Error: Entry must be from 1 to 5000 (the YouTube API Limit)")
+            print("Error: Entry must be from 1 to 5000 (the YouTube API Limit)", file=sys.stderr)
             validEntry = False
             validConfigSetting = False
         except ValueError:
-          print(f"{F.LIGHTRED_EX}Error:{S.R} Entry must be a whole number greater than zero.")
+          print(f"{F.LIGHTRED_EX}Error:{S.R} Entry must be a whole number greater than zero.", file=sys.stderr)
           validEntry = False
         if validEntry == True and numVideos >= 1000:
           print(f"\n{B.YELLOW}{F.BLACK} WARNING: {S.R} You have chosen to scan a large amount of videos. With the default API quota limit,")
@@ -695,7 +695,7 @@ def main():
           if str(videosToScan) == "MainMenu":
             return True # Return to main menu
           if len(videosToScan) == 0:
-            print(f"\n{F.LIGHTRED_EX}Error:{S.R} No scannable videos found in selected range!  They all may have no comments and/or are live streams.")
+            print(f"\n{F.LIGHTRED_EX}Error:{S.R} No scannable videos found in selected range!  They all may have no comments and/or are live streams.", file=sys.stderr)
             if config['auto_close'] == True:
               print("Auto-close enabled in config. Exiting in 5 seconds...")
               time.sleep(5)
@@ -908,11 +908,11 @@ def main():
             numRecentPosts = len(recentPostsListofDicts)
             break
           elif numRecentPosts <= 0:
-            print("Please enter a whole number greater than zero.")
+            print("Please enter a whole number greater than zero.", file=sys.stderr)
           else:
             break
         except ValueError:
-          print("Invalid Input! - Must be a whole number.")
+          print("Invalid Input! - Must be a whole number.", file=sys.stderr)
 
       miscData.channelOwnerID = channelID
       miscData.channelOwnerName = channelTitle
@@ -1269,7 +1269,7 @@ def main():
         bypass = False
       else:
         bypass = False
-        print("Error Code C-2: Invalid value for 'enable_logging' in config file:  " + logSetting)
+        print("Error Code C-2: Invalid value for 'enable_logging' in config file:  " + logSetting, file=sys.stderr)
 
     # Counts number of found spam comments and prints list
     if not current.matchedCommentsDict and not current.duplicateCommentsDict and not current.spamThreadsDict and not current.repostedCommentsDict: # If no spam comments found, exits
@@ -1346,7 +1346,7 @@ def main():
     if userNotChannelOwner == True and filterMode not in filterModesAllowedforNonOwners:
       confirmDelete = False
       deletionEnabled = False
-      print(f"{F.LIGHTRED_EX}Error:{S.R}To prevent abuse, even in moderator mode, you can only use filter modes: Auto Smart, Sensitive Smart, and ID")
+      print(f"{F.LIGHTRED_EX}Error:{S.R}To prevent abuse, even in moderator mode, you can only use filter modes: Auto Smart, Sensitive Smart, and ID", file=sys.stderr)
       response = input("Press Enter to Continue, or type 'x' to return to Main Menu...")
       if response.lower() == 'x':
         return True
@@ -1357,7 +1357,7 @@ def main():
       returnToMenu = True
 
     elif config['skip_deletion'] != False:
-      print("Error Code C-3: Invalid value for 'skip_deletion' in config file. Must be 'True' or 'False'. Current Value:  " + str(config['skip_deletion']))
+      print("Error Code C-3: Invalid value for 'skip_deletion' in config file. Must be 'True' or 'False'. Current Value:  " + str(config['skip_deletion']), file=sys.stderr)
       print(f"Defaulting to '{F.YELLOW}False{S.R}'")
       input("\nPress Enter to Continue...")
 
@@ -1374,7 +1374,7 @@ def main():
       elif config['removal_type'] == "rejected":
         deletionMode = "rejected"
       else:
-        print("Error Code C-4: Invalid value for 'removal_type' in config file. Must be 'heldforreview', 'rejected', or 'reportSpam':  " + config['removal_type'])
+        print("Error Code C-4: Invalid value for 'removal_type' in config file. Must be 'heldforreview', 'rejected', or 'reportSpam':  " + config['removal_type'], file=sys.stderr)
         input("\nPress Enter to Exit...")
         sys.exit()
 
@@ -1395,14 +1395,14 @@ def main():
             confirmDelete = "hold"
         else:
           # If non-permitted filter mode with delete_without_reviewing, will allow deletion, but now warns and requires usual confirmation prompt
-          print("Error Code C-5: 'delete_without_reviewing' is set to 'True' in config file. So only filter mode 'AutoSmart' allowed..\n")
+          print("Error Code C-5: 'delete_without_reviewing' is set to 'True' in config file. So only filter mode 'AutoSmart' allowed..\n", file=sys.stderr)
           print("Next time use one of those filter modes, or set 'delete_without_reviewing' to 'False'.")
           print("    > For this run, you will be asked to confirm removal of spam comments.")
           input("\nPress Enter to Continue...")
           confirmDelete = None
           deletionEnabled = "Allowed"
       else:
-        print("Error Code C-6: 'delete_without_reviewing' is set to 'True' in config file. So 'removal_type' must be either 'heldForReview' or 'reportSpam'.\n")
+        print("Error Code C-6: 'delete_without_reviewing' is set to 'True' in config file. So 'removal_type' must be either 'heldForReview' or 'reportSpam'.\n", file=sys.stderr)
         print("Next time, either set one of those removal types, or set 'delete_without_reviewing' to 'False'.")
         print("    > For this run, you will be asked to confirm removal of spam comments.")
         input("\nPress Enter to Continue...")
@@ -1410,7 +1410,7 @@ def main():
         deletionEnabled = "Allowed"
     else:
       # Catch Invalid value
-      print("Error C-7: Invalid value for 'delete_without_reviewing' in config file. Must be 'True' or 'False':  " + config['delete_without_reviewing'])
+      print("Error C-7: Invalid value for 'delete_without_reviewing' in config file. Must be 'True' or 'False':  " + config['delete_without_reviewing'], file=sys.stderr)
       input("\nPress Enter to Exit...")
       sys.exit()
 
@@ -1531,7 +1531,7 @@ def main():
           returnToMenu = True
 
         else:
-          print(f"\n{F.LIGHTRED_EX}ERROR:{S.R} This entry was invalid or not allowed with current settings: {confirmDelete}")
+          print(f"\n{F.LIGHTRED_EX}ERROR:{S.R} This entry was invalid or not allowed with current settings: {confirmDelete}", file=sys.stderr)
           input("\nPress Enter to try again...")
           print("\n")
 
@@ -1559,10 +1559,10 @@ def main():
           if config['enable_ban'] == False:
             pass
           elif config['enable_ban'] == True:
-            print("Error Code C-8: 'enable_ban' is set to 'True' in config file. Only possible config options are 'ask' or 'False' when using config.\n")
+            print("Error Code C-8: 'enable_ban' is set to 'True' in config file. Only possible config options are 'ask' or 'False' when using config.\n", file=sys.stderr)
             input("Press Enter to Continue...")
           else:
-            print("Error Code C-9: 'enable_ban' is set to an invalid value in config file. Only possible config options are 'ask' or 'False' when using config.\n")
+            print("Error Code C-9: 'enable_ban' is set to an invalid value in config file. Only possible config options are 'ask' or 'False' when using config.\n", file=sys.stderr)
             input("Press Enter to Continue...")
         elif deletionMode == "rejected":
           print("\nAlso ban the spammer(s)?")
@@ -1720,26 +1720,26 @@ if __name__ == "__main__":
   except HttpError as hx:
     traceback.print_exc()
     print("------------------------------------------------")
-    print("Error Message: " + str(hx))
+    print("Error Message: " + str(hx), , file=sys.stderr)
     if hx.status_code:
       print("Status Code: " + str(hx.status_code))
       if hx.error_details[0]["reason"]: # If error reason is available, print it
           reason = str(hx.error_details[0]["reason"])
           utils.print_exception_reason(reason)
-      print(f"\nAn {F.LIGHTRED_EX}'HttpError'{S.R} was raised. This is sometimes caused by a remote server error. See the error info above.")
+      print(f"\nAn {F.LIGHTRED_EX}'HttpError'{S.R} was raised. This is sometimes caused by a remote server error. See the error info above.", file=sys.stderr)
       print(f"If this keeps happening, consider posting a bug report on the GitHub issues page, and include the above error info.")
       print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
       input("\nPress Enter to Exit...")
     else:
-      print(f"{F.LIGHTRED_EX}Unknown Error - Code: Z-1{S.R} occurred. If this keeps happening, consider posting a bug report on the GitHub issues page, and include the above error info.")
+      print(f"{F.LIGHTRED_EX}Unknown Error - Code: Z-1{S.R} occurred. If this keeps happening, consider posting a bug report on the GitHub issues page, and include the above error info.", file=sys.stderr)
       print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
       input("\n Press Enter to Exit...")
   except UnboundLocalError as ux:
     traceback.print_exc()
     print("------------------------------------------------")
-    print("Error Message: " + str(ux))
+    print("Error Message: " + str(ux), file=sys.stderr)
     if "referenced before assignment" in str(ux):
-      print(f"\n{F.LIGHTRED_EX}Error - Code: X-2{S.R} occurred. This is almost definitely {F.YELLOW}my fault and requires patching{S.R} (big bruh moment)")
+      print(f"\n{F.LIGHTRED_EX}Error - Code: X-2{S.R} occurred. This is almost definitely {F.YELLOW}my fault and requires patching{S.R} (big bruh moment)", file=sys.stderr)
       print(f"Please post a bug report on the GitHub issues page, and include the above error info.")
       print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
       print("    (In the mean time, try using a previous release of the program.)")
@@ -1747,7 +1747,7 @@ if __name__ == "__main__":
     else:
       traceback.print_exc()
       print("------------------------------------------------")
-      print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-2{S.R} occurred. If this keeps happening,")
+      print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-2{S.R} occurred. If this keeps happening,", file=sys.stderr)
       print("consider posting a bug report on the GitHub issues page, and include the above error info.")
       print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
       input("\n Press Enter to Exit...")
@@ -1755,18 +1755,18 @@ if __name__ == "__main__":
     traceback.print_exc()
     print("------------------------------------------------")
     if "config" in str(kx):
-      print(f"{F.LIGHTRED_EX}Unknown Error - Code: X-3{S.R}")
+      print(f"{F.LIGHTRED_EX}Unknown Error - Code: X-3{S.R}", file=sys.stderr)
       print("Are you using an outdated version of the config file? Try re-creating the config file to get the latest version.")
       print(f"{F.LIGHTYELLOW_EX}If that doesn't work{S.R}, consider posting a {F.LIGHTYELLOW_EX}bug report{S.R} on the GitHub issues page, and include the above error info.")
     else:
-      print(f"{F.RED}Unknown Error - Code: X-4{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},")
+      print(f"{F.RED}Unknown Error - Code: X-4{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},", file=sys.stderr)
       print(f"please post a {F.LIGHTYELLOW_EX}bug report{S.R} on the GitHub issues page, and include the above error info.")
     print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")
   except TypeError:
     traceback.print_exc()
     print("------------------------------------------------")
-    print(f"{F.RED}Unknown Error - Code: X-5{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},")
+    print(f"{F.RED}Unknown Error - Code: X-5{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},", file=sys.stderr)
     print(f"please post a {F.LIGHTYELLOW_EX}bug report{S.R} on the GitHub issues page, and include the above error info.")
     print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")
@@ -1776,8 +1776,8 @@ if __name__ == "__main__":
   except Exception as x:
     traceback.print_exc()
     print("------------------------------------------------")
-    print("Error Message: " + str(x))
-    print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-3{S.R} occurred. If this keeps happening, consider posting a bug report")
+    print("Error Message: " + str(x), file=sys.stderr)
+    print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-3{S.R} occurred. If this keeps happening, consider posting a bug report", file=sys.stderr)
     print("on the GitHub issues page, and include the above error info.")
     print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")


### PR DESCRIPTION
# Redirects errors to `stderr`

### Related Issue/Addition to code
- Addition to code: I have simply added a second argument to all `print` calls that intend to print an error, that second argument being the file descriptor of the `stderr` buffer. There are [several reasons](https://stackoverflow.com/questions/19870331/why-use-stderr-when-printf-works-fine) why: the most obvious being best practice, and no buffering.

#### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Proposed Changes
- Change all `print('Error: ...')` error messages to `print('Error: ...', file=sys.stderr)` instead.

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
This change is needed to maintain the overall code quality of this project. Printing error messages to `sys.stderr` is a practice that should be adhered to by all code. See [this](https://stackoverflow.com/questions/3385201/confused-about-stdin-stdout-and-stderr) for more information about what `sys.stderr` (or just `stderr`) is.

### Checklist:
- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings