### PR TITLE
added additional packages to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3-slim AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc \
-    cmake
+    cmake \
+    python-dev \
+    build-essential
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --user -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim AS builder
 RUN apt-get update && \
     apt-get install -y gcc \
     cmake \
-    python-dev \
+    python3-dev \
     build-essential
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --user -r requirements.txt


### PR DESCRIPTION
### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Fixes #1017
- Follow up to PR #1032 

#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Proposed Changes

- in addition to cmake we also need python3-dev and build-essential build the docker image

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
Docker build would not fail for armv6 and armv7

### Additional Info
- armv6 and v7 build would not fail now

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code