### PR TITLE
Check moderator mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3-slim AS builder
 
 RUN apt-get update && \
-    apt-get install -y gcc
+    apt-get install -y gcc \
+    cmake
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --user -r requirements.txt
 

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -1380,7 +1380,7 @@ def main():
 
     # User wants to automatically delete with no user intervention
     elif config['delete_without_reviewing'] == True:
-      if userNotChannelOwner == True:
+      if userNotChannelOwner == True and moderator_mode == False:
           confirmDelete = "report"
           deletionMode = "reportSpam"
           deletionEnabled = True


### PR DESCRIPTION
### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Fixes #935 
- Addition to code.

#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Proposed Changes
- ´moderator_mode´ is checked before setting removal defaults
### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It's needed because "User wants to automatically delete with no user intervention" code doesn't check if moderator_mode is enabled when setting default confirmDelete and deletionMode values, which prevents moderators from automatically holding comments for review.

### Additional Info
- this issue prevents moderators from fully automating the removal (holding for review) of comments on the channels they moderate

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---

### Screenshots

Original | Updated
:----------------------:|:-----------:
** original screenshot  | ** updated screenshot **
