### PR TITLE
JSON schema and yaml support

### DIFF
--- a/Scripts/generate_json_schema.nu
+++ b/Scripts/generate_json_schema.nu
@@ -1,0 +1,121 @@
+def generate-key-arguments [key: string, restrictions: record] {
+    $restrictions |
+        transpose |
+        rename key value |
+        each {|$it| $'--arg ($key)_($it.key) ($it.value)'}
+}
+
+# Generates JSON schema.
+def generate-schema [config_url: string] {
+    let schema = $"http://json-schema.org/draft-07/schema"
+
+    let non_inferred = [
+        { key: use_this_config, type: [string, boolean] },
+        { key: max_comments, type: [string, integer] },
+        { key: recent_videos_amount, type: [string, integer], minimum: 1, maximum: 5000 },
+        { key: autoASCII_sensitivity, type: [string, integer], minimum: 1, maximum: 3 },
+        { key: enable_ban, type: [string, boolean] },
+        { key: remove_all_author_comments, type: [string, boolean] },
+        { key: whitelist_excluded, type: [string, boolean] },
+        { key: enable_logging, type: [string, boolean] },
+        { key: json_profile_picture, type: [string, boolean] },
+        { key: minimum_duplicates, minimum: 3 },
+        { key: minimum_duplicate_length, minimum: 1 },
+        { key: levenshtein_distance, minimum: 0, maximum: 1 },
+        { key: stolen_minimum_text_length, minimum: 1 }
+    ]
+
+    let additional_jq_args = ($non_inferred |
+        each {|$it| generate-key-arguments $it.key ($it | reject key)} |
+        flatten |
+        str replace --all ', '  ',' |
+        str replace --all '\[|\]' '' |
+        str join " " |
+        split row " ")
+
+    http get --raw $config_url |
+        jc --ini |
+        str replace --all '"(\d+(\.\d+)?)"' '$1' |
+        str replace --all '"(True)"' 'true' |
+        str replace --all '"(False)"' 'false' |
+        jq 'def to_title: . | gsub("_"; " ") | ascii_downcase;
+        def to_description: . | to_title + "\n" + $url;
+        
+        def to_singular:
+            if . | test("^[aeiouy]"; "i") then
+                . | sub("^(?<x>.*?)s\n"; "An \(.x)\n")
+            else
+                . | sub("^(?<x>.*?)s\n"; "A \(.x)\n")
+            end;
+
+        def to_type(key; value):
+            (key + "_type") as $type |
+            if $ARGS.named[$type] != null then
+                $ARGS.named[$type] | split(",")
+            else
+                value | type
+            end;
+
+        def to_restrictions:
+            (. + "_minimum") as $min |
+            (. + "_maximum") as $max |
+            if $ARGS.named[$min] != null then
+                { minimum: $ARGS.named[$min] | tonumber }
+            else
+                {}
+            end +
+            if $ARGS.named[$max] != null then
+                { maximum: $ARGS.named[$max] | tonumber }
+            else
+                {}
+            end;
+        
+        def wrap: {
+            type: "object",
+            properties: with_entries(
+                if .value | type != "object" then
+                    {
+                        key,
+                        value: ({
+                            title: .key | to_title,
+                            description: .key | to_description,
+                            type: to_type(.key; .value),
+                        } +
+                        if .value | tostring | test("^\\d+$") then
+                            { type: "integer" }
+                        else
+                            {}
+                        end +
+                        (.key | to_restrictions) +
+                        {
+                            default: .value
+                        })
+                    }
+                else
+                    .value = {
+                        title: .key | to_title,
+                        description: .key | to_description
+                    } + (.value | wrap) + {
+                        additionalProperties: false
+                    }
+                end)
+            };
+        
+        {
+            "$schema": $schema,
+            title: "config",
+            description: "A config"
+        } + (. | wrap)' --arg url $config_url --arg schema $schema $additional_jq_args
+}
+
+def main [
+    --generate-schema (-g) # Whether to generate JSON schema from INI file for YAML file.
+    --rewrite-config (-r) # Whether to rewrite INI config from YAML config.
+] {
+    let config_url = https://raw.githubusercontent.com/ThioJoe/YT-Spammer-Purge/main/assets/default_config.ini
+
+    if $generate_schema {
+        generate-schema $config_url
+    }
+}
+

--- a/Scripts/generate_json_schema.nu
+++ b/Scripts/generate_json_schema.nu
@@ -1,5 +1,6 @@
 def generate-key-arguments [key: string, restrictions: record] {
     $restrictions |
+        reject key |
         transpose |
         rename key value |
         each {|$it| $'--arg ($key)_($it.key) ($it.value)'}
@@ -26,7 +27,7 @@ def generate-schema [config_url: string] {
     ]
 
     let additional_jq_args = ($non_inferred |
-        each {|$it| generate-key-arguments $it.key ($it | reject key)} |
+        each {|$it| generate-key-arguments $it.key $it} |
         flatten |
         str replace --all ', '  ',' |
         str replace --all '\[|\]' '' |


### PR DESCRIPTION
### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Addition to code.

#### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Proposed Changes
- JSON schema generator and converter to .ini file

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It's needed because there is no intellisence available for .ini files.

### Additional Info
This script allows to:

- generate JSON schema for YAML config (from remote default INI config in this repo)
- rewrite INI config from YAML config (not to write INI directly)

It means that users can configure tool via YAML having intellisence and validation. Script is written in Nushell.

### Checklist:

- [ ] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---

### Screenshots

Original | Updated
:----------------------:|:-----------:
** original screenshot  | ** updated screenshot **
