### PR TITLE
fix highlight of TJoe.io links

### DIFF
--- a/Scripts/auth.py
+++ b/Scripts/auth.py
@@ -49,7 +49,7 @@ def get_authenticated_service():
     else:
       print(f"\n         ----- {F.WHITE}{B.RED}[!] Error:{S.R} client_secrets.json file not found -----")
       print(f" ----- Did you create a {F.YELLOW}Google Cloud Platform Project{S.R} to access the API? ----- ")
-      print(f"  > For instructions on how to get an API key, visit: {F.YELLOW}TJoe.io/api-setup{S.R}")
+      print(f"  > For instructions on how to get an API key, visit: {F.YELLOW}https://TJoe.io/api-setup{S.R}")
       print(f"\n  > (Non-shortened Link: https://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key)")
       input("\nPress Enter to Exit...")
       sys.exit()

--- a/Scripts/files.py
+++ b/Scripts/files.py
@@ -277,9 +277,9 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
     if silentCheck == False:
       print("------------------------------------------------------------------------------------------")
       if isBeta == True:
-        print(f" {F.YELLOW}A new {F.LIGHTGREEN_EX}beta{F.YELLOW} version{S.R} is available! Visit {F.YELLOW}TJoe.io/latest{S.R} to see what's new.")
+        print(f" {F.YELLOW}A new {F.LIGHTGREEN_EX}beta{F.YELLOW} version{S.R} is available! Visit {F.YELLOW}https://TJoe.io/latest{S.R} to see what's new.")
       else:
-        print(f" A {F.LIGHTGREEN_EX}new version{S.R} is available! Visit {F.YELLOW}TJoe.io/latest{S.R} to see what's new.")
+        print(f" A {F.LIGHTGREEN_EX}new version{S.R} is available! Visit {F.YELLOW}https://TJoe.io/latest{S.R} to see what's new.")
       print(f"   > Current Version: {currentVersion}")
       print(f"   > Latest Version: {F.LIGHTGREEN_EX}{latestVersion}{S.R}")
       if isBeta == True:
@@ -387,7 +387,7 @@ def check_for_update(currentVersion, updateReleaseChannel, silentCheck=False):
             print("\nYou can now delete the old version. (Or keep it around in case you encounter any issues with the new version)")
           else:
             print(f"\n{F.LIGHTYELLOW_EX}NOTE:{S.R} Because this is a {F.CYAN}beta release{S.R}, you should keep the old version around in case you encounter any issues")
-            print(f" > And don't forget to report any problems you encounter here: {F.YELLOW}TJoe.io/bug-report{S.R}")
+            print(f" > And don't forget to report any problems you encounter here: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
           input("\nPress Enter to Exit...")
           sys.exit()
         elif os.name == "posix":

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -731,7 +731,7 @@ def check_against_filter(current, filtersDict, miscData, config, currentCommentD
   commentText = str(currentCommentDict['commentText']).replace("\r", "")
 
   # #Debugging
-  # print(f"{F.LIGHTRED_EX}DEBUG MODE{S.R} - If you see this, I forgot to disable it before release, oops. \n Please report here: {F.YELLOW}TJoe.io/bug-report{S.R}")
+  # print(f"{F.LIGHTRED_EX}DEBUG MODE{S.R} - If you see this, I forgot to disable it before release, oops. \n Please report here: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
   # print("Comment ID: " + commentID)
   # debugSingleComment = True #Debug usage
   # if debugSingleComment == True:

--- a/Scripts/prepare_modes.py
+++ b/Scripts/prepare_modes.py
@@ -636,7 +636,7 @@ def delete_comment_list(config):
         if countChoice > 0 and countChoice <= quotaLimit:
           validInput = True
         elif countChoice >= quotaLimit:
-          print(f"\n{F.LIGHTRED_EX}Error:{S.R} {countChoice} is too many comments, you'll run out of API Quota. Read Here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+          print(f"\n{F.LIGHTRED_EX}Error:{S.R} {countChoice} is too many comments, you'll run out of API Quota. Read Here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
         else:
           print(f"Invalid input, must be 'all' or a whole number from 1 to {str(quotaLimit)}.")
     except:

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -181,7 +181,7 @@ def print_exception_reason(reason):
     print(" > There is a daily limit of 10,000 units/day, which works out to around reporting 10,000 comments/day.")
     print(" > You can check your quota by searching 'quota' in the Google Cloud console.")
     print(f"{F.YELLOW}Solutions: Either wait until tomorrow, or create additional projects in the cloud console.{S.R}")
-    print(f"  > Read more about the quota limits for this app here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+    print(f"  > Read more about the quota limits for this app here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
 
 def print_http_error_during_scan(hx):
   print("------------------------------------------------")

--- a/Scripts/validation.py
+++ b/Scripts/validation.py
@@ -59,7 +59,7 @@ def validate_video_id(video_url_or_id, silent=False, pass_exception=False, basic
             print("--------------------------------------")
             print(f"\n{B.RED}{F.WHITE} ERROR: {S.R} {F.RED}Unable to get comment count for video: {S.R} {possibleVideoID}  |  {videoTitle}")
             print(f"\n{F.YELLOW}Are comments disabled on this video?{S.R} If not, please report the bug and include the error info above.")
-            print(f"                    Bug Report Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+            print(f"                    Bug Report Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
             input("\nPress Enter to return to the main menu...")
             return "MainMenu", "MainMenu", "MainMenu", "MainMenu", "MainMenu"
             
@@ -239,7 +239,7 @@ def validate_config_settings(config):
 
   # Helper Functions
   def print_quit_and_report():
-    print(f"\nIf you think this is a bug or can't figure it out, report it on the GitHub page:  {F.YELLOW}TJoe.io/bug-report{S.R}")
+    print(f"\nIf you think this is a bug or can't figure it out, report it on the GitHub page:  {F.YELLOW}https://TJoe.io/bug-report{S.R}")
     input("\nPress Enter to exit...")
     sys.exit()
 
@@ -513,7 +513,7 @@ def validate_config_settings(config):
       elif result == None:
         print(f"\n{B.RED}{F.WHITE} WARNING! {S.R} An unknown setting was found:  '{settingName}': {str(settingValue)}")
         print(f"If you didn't add or change this setting in the config file, a validation check was probably forgotten to be created!")
-        print(f"Consider reporting it: {F.YELLOW}TJoe.io/bug-report{S.R}")
+        print(f"Consider reporting it: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
         input(f"\n It might not cause an issue, so press Enter to Continue anyway...")
         continue
   

--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -608,7 +608,7 @@ def main():
             if miscData.totalCommentCount >= 100000:
               print(f"\n{B.YELLOW}{F.BLACK} WARNING: {S.R} You have chosen to scan a large amount of comments. The default API quota limit ends up")
               print(f" around {F.YELLOW}10,000 comment deletions per day{S.R}. If you find more spam than that you will go over the limit.")
-              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
               if userNotChannelOwner == False or moderator_mode == True:
                 print(f"{F.LIGHTCYAN_EX}> Note:{S.R} You may want to disable 'check_deletion_success' in the config, as this doubles the API cost! (So a 5K limit)")
             confirm = choice("Is this video list correct?", bypass=validConfigSetting)
@@ -687,7 +687,7 @@ def main():
         if validEntry == True and numVideos >= 1000:
           print(f"\n{B.YELLOW}{F.BLACK} WARNING: {S.R} You have chosen to scan a large amount of videos. With the default API quota limit,")
           print(f" every 1000 videos will use up 20% of the quota {F.YELLOW}just from listing the videos alone, before any comment scanning.{S.R}")
-          print(f"        > Read more about the quota limits for this app here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+          print(f"        > Read more about the quota limits for this app here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
 
         if validEntry == True:
           # Fetch recent videos and print titles to user for confirmation
@@ -734,7 +734,7 @@ def main():
             if miscData.totalCommentCount >= 100000:
               print(f"\n{B.YELLOW}{F.BLACK} WARNING: {S.R} You have chosen to scan a large amount of comments. The default API quota limit ends up")
               print(f" around {F.YELLOW}10,000 comment deletions per day{S.R}. If you find more spam than that you will go over the limit.")
-              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
               if userNotChannelOwner == True or moderator_mode == True:
                 print(f"{F.LIGHTCYAN_EX}> Note:{S.R} You may want to disable 'check_deletion_success' in the config, as this doubles the API cost! (So a 5K limit)")
             confirm = choice("Is everything correct?", bypass=config['skip_confirm_video'])
@@ -765,7 +765,7 @@ def main():
             if maxScanNumber >= 100000:
               print(f"\n{B.YELLOW}{F.BLACK} WARNING: {S.R} You have chosen to scan a large amount of comments. The default API quota limit ends up")
               print(f" around {F.YELLOW}10,000 comment deletions per day{S.R}. If you find more spam than that you will go over the limit.")
-              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}TJoe.io/api-limit-info{S.R}")
+              print(f"        > Read more about the quota limits for this app here: {F.YELLOW}https://TJoe.io/api-limit-info{S.R}")
               if userNotChannelOwner == True or moderator_mode == True:
                 print(f"{F.LIGHTCYAN_EX}> Note:{S.R} You may want to disable 'check_deletion_success' in the config, as this doubles the API cost! (So a 5K limit)")
               userChoice = choice("Do you still want to continue?")
@@ -1274,7 +1274,7 @@ def main():
     # Counts number of found spam comments and prints list
     if not current.matchedCommentsDict and not current.duplicateCommentsDict and not current.spamThreadsDict and not current.repostedCommentsDict: # If no spam comments found, exits
       print(f"{B.RED}{F.BLACK} No matched comments or users found! {F.R}{B.R}{S.R}\n")
-      print(f"If you see missed spam or false positives, you can submit a filter suggestion here: {F.YELLOW}TJoe.io/filter-feedback{S.R}")
+      print(f"If you see missed spam or false positives, you can submit a filter suggestion here: {F.YELLOW}https://TJoe.io/filter-feedback{S.R}")
 
       # Can still log to json even though no comments
       if config['json_log_all_comments'] and config['json_log'] and config['enable_logging'] != False:
@@ -1327,7 +1327,7 @@ def main():
     logFileContents, logMode = logging.print_comments(current, config, scanVideoID, loggingEnabled, scanMode, logMode)
 
     print(f"\n{F.WHITE}{B.RED} NOTE: {S.R} Check that all comments listed above are indeed spam.")
-    print(f" > If you see missed spam or false positives, you can submit a filter suggestion here: {F.YELLOW}TJoe.io/filter-feedback{S.R}")
+    print(f" > If you see missed spam or false positives, you can submit a filter suggestion here: {F.YELLOW}https://TJoe.io/filter-feedback{S.R}")
     print()
 
     ### ---------------- Decide whether to skip deletion ----------------
@@ -1418,7 +1418,7 @@ def main():
     if returnToMenu == False and deletionEnabled != "Allowed" and deletionEnabled != True:
         print("\nThe deletion functionality was not enabled. Cannot delete or report comments.")
         print("Possible Cause: You're scanning someone else's video with a non-supported filter mode.\n")
-        print(f"If you think this is a bug, you may report it on this project's GitHub page: {F.YELLOW}TJoe.io/bug-report{S.R}")
+        print(f"If you think this is a bug, you may report it on this project's GitHub page: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
         if config['auto_close'] == True:
           print("\nAuto-close enabled in config. Exiting in 5 seconds...")
           time.sleep(5)
@@ -1728,11 +1728,11 @@ if __name__ == "__main__":
           utils.print_exception_reason(reason)
       print(f"\nAn {F.LIGHTRED_EX}'HttpError'{S.R} was raised. This is sometimes caused by a remote server error. See the error info above.")
       print(f"If this keeps happening, consider posting a bug report on the GitHub issues page, and include the above error info.")
-      print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+      print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
       input("\nPress Enter to Exit...")
     else:
       print(f"{F.LIGHTRED_EX}Unknown Error - Code: Z-1{S.R} occurred. If this keeps happening, consider posting a bug report on the GitHub issues page, and include the above error info.")
-      print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+      print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
       input("\n Press Enter to Exit...")
   except UnboundLocalError as ux:
     traceback.print_exc()
@@ -1741,7 +1741,7 @@ if __name__ == "__main__":
     if "referenced before assignment" in str(ux):
       print(f"\n{F.LIGHTRED_EX}Error - Code: X-2{S.R} occurred. This is almost definitely {F.YELLOW}my fault and requires patching{S.R} (big bruh moment)")
       print(f"Please post a bug report on the GitHub issues page, and include the above error info.")
-      print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+      print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
       print("    (In the mean time, try using a previous release of the program.)")
       input("\n Press Enter to Exit...")
     else:
@@ -1749,7 +1749,7 @@ if __name__ == "__main__":
       print("------------------------------------------------")
       print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-2{S.R} occurred. If this keeps happening,")
       print("consider posting a bug report on the GitHub issues page, and include the above error info.")
-      print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+      print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
       input("\n Press Enter to Exit...")
   except KeyError as kx:
     traceback.print_exc()
@@ -1761,14 +1761,14 @@ if __name__ == "__main__":
     else:
       print(f"{F.RED}Unknown Error - Code: X-4{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},")
       print(f"please post a {F.LIGHTYELLOW_EX}bug report{S.R} on the GitHub issues page, and include the above error info.")
-    print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+    print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")
   except TypeError:
     traceback.print_exc()
     print("------------------------------------------------")
     print(f"{F.RED}Unknown Error - Code: X-5{S.R} occurred. This is {F.YELLOW}probably my fault{S.R},")
     print(f"please post a {F.LIGHTYELLOW_EX}bug report{S.R} on the GitHub issues page, and include the above error info.")
-    print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+    print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")
   except KeyboardInterrupt:
     print("\n\nProcess Cancelled via Keyboard Shortcut")
@@ -1779,7 +1779,7 @@ if __name__ == "__main__":
     print("Error Message: " + str(x))
     print(f"\n{F.LIGHTRED_EX}Unknown Error - Code: Z-3{S.R} occurred. If this keeps happening, consider posting a bug report")
     print("on the GitHub issues page, and include the above error info.")
-    print(f"Short Link: {F.YELLOW}TJoe.io/bug-report{S.R}")
+    print(f"Short Link: {F.YELLOW}https://TJoe.io/bug-report{S.R}")
     input("\n Press Enter to Exit...")
   else:
     print("\nFinished Executing.")

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ update () {
 
     echo "--------------------------"
     echo "Updated!"
-    echo "Report any bugs to TJoe.io/bug-report"
+    echo "Report any bugs to https://TJoe.io/bug-report"
     exit 0
 }
 


### PR DESCRIPTION
Not a common reality on Windows shells but many
Linux shells have a feature that you can click,
or Ctrl+Click on links to open them but right
now the links to TJoe.io are incomplete and not
recognized as links by the shell.

### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Fixes #<!--issue-no-->
- Addition to code.

#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Proposed Changes
- Add https prefixes to TJoe.io URLs

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
One can now click, or Ctrl+click on links instead of copypasting them on supported shells such as Terminator or Kitty

### Additional Info
I tested it on Kitty and now clicking on links works!

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---

### Screenshots

Original | Updated
:----------------------:|:-----------:
** ![image](https://github.com/ThioJoe/YT-Spammer-Purge/assets/15693688/51dcdb7d-31ed-482e-ab70-b2e115291fec)  | ** ![image](https://github.com/ThioJoe/YT-Spammer-Purge/assets/15693688/cc8c83bf-c143-4ce3-806f-0a775e726e0a) **



