### PR TITLE
optimize check_duplicates in operations.py

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -608,7 +608,7 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
     else:
       numDupes = 0
       commentTextList = []
-      matchedIndexes = []
+      matchedIndexes = set()
       for commentDict in authorCommentsList:
         # Adding to use as lower case, because levenshtein is case sensitive. Also, root domain list is ingested as lower case, so necessary to compare
         commentTextList.append(commentDict['commentText'].lower())
@@ -622,24 +622,21 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
               y = commentTextList[j]
               # If Levenshtein distance is 1.0, then only check if comment text is exactly the same
               if levenshtein == 1.0 and x == y: 
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                matchedIndexes.update([i, j])
                 break
               # If Levenshtein distance is 0, don't check at all, just count number of comments by user
               elif levenshtein == 0.0:
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                matchedIndexes.update([i, j])
                 break
               elif fuzz.ratio(x,y) / 100 > levenshtein:
                 # List the indexes of the matched comments in the list
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                matchedIndexes.update([i, j])
                 break
           else:
             break
         
         # Only count each comment once by counting number of unique indexes in matchedIndexes
-        uniqueMatches = len(set(matchedIndexes))
+        uniqueMatches = len(matchedIndexes)
         if uniqueMatches >= minimum_duplicates:
           numDupes += uniqueMatches
       if numDupes > 0:


### PR DESCRIPTION
there is a list that ends up being converted  to a set to check the length, there is not a use before that which requires a proper order so i changed it to be a set from the start so that the loop that adds to it runs faster

### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->
- Addition to code.

### Proposed Changes
- convert a  list to a set

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It will improve performance of  this heavily used  essential function

### Additional Info
- any additional info for context

### Checklist:

- [*] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [*] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [*] Any dependent changes have been merged and published in downstream modules
- [*] I have checked my code and corrected any misspellings

---

### Screenshots

Original | Updated
:----------------------:|:-----------:
** original screenshot  | ** updated screenshot **
