### PR TITLE
speed up check_duplicates and reduce ram usage

### DIFF
--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -580,7 +580,7 @@ def get_all_author_comments(current, config, miscData, allCommentsDict):
 
 ############################## Check Duplicates ######################################
 def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
-  domainList =  miscData.resources['rootDomainList']
+  domainList =  [f".{domain}" for domain in miscData.resources['rootDomainList']]
 
   # Get Lenvenshtein Distance Setting - Does not need to be validated here, because that happens at beginning of program
   levenshtein = float(config['levenshtein_distance'])
@@ -617,7 +617,7 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
       if len(commentTextList) > 1:
         for i,x in enumerate(commentTextList):
           # Check length of comment against minimum, but override if a domain is detected
-          if len(x) >= minimum_duplicate_length or (len(x) >= 6 and any(f".{domain}" in x for domain in domainList)):
+          if len(x) >= minimum_duplicate_length or (len(x) >= 6 and any(domain} in x for domain in domainList)):
             for j in range(i+1,len(commentTextList)):
               y = commentTextList[j]
               # If Levenshtein distance is 1.0, then only check if comment text is exactly the same

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -608,7 +608,7 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
     else:
       numDupes = 0
       commentTextList = []
-      matchedIndexes = []
+      uniqueMatches = 0
       for commentDict in authorCommentsList:
         # Adding to use as lower case, because levenshtein is case sensitive. Also, root domain list is ingested as lower case, so necessary to compare
         commentTextList.append(commentDict['commentText'].lower())
@@ -622,24 +622,20 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
               y = commentTextList[j]
               # If Levenshtein distance is 1.0, then only check if comment text is exactly the same
               if levenshtein == 1.0 and x == y: 
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                uniqueMatches += 2
                 break
               # If Levenshtein distance is 0, don't check at all, just count number of comments by user
               elif levenshtein == 0.0:
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                uniqueMatches += 2
                 break
               elif fuzz.ratio(x,y) / 100 > levenshtein:
                 # List the indexes of the matched comments in the list
-                matchedIndexes.append(i)
-                matchedIndexes.append(j)
+                uniqueMatches += 2
                 break
           else:
             break
         
         # Only count each comment once by counting number of unique indexes in matchedIndexes
-        uniqueMatches = len(set(matchedIndexes))
         if uniqueMatches >= minimum_duplicates:
           numDupes += uniqueMatches
       if numDupes > 0:

--- a/Scripts/operations.py
+++ b/Scripts/operations.py
@@ -608,7 +608,7 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
     else:
       numDupes = 0
       commentTextList = []
-      uniqueMatches = 0
+      matchedIndexes = set()
       for commentDict in authorCommentsList:
         # Adding to use as lower case, because levenshtein is case sensitive. Also, root domain list is ingested as lower case, so necessary to compare
         commentTextList.append(commentDict['commentText'].lower())
@@ -622,20 +622,24 @@ def check_duplicates(current, config, miscData, allVideoCommentsDict, videoID):
               y = commentTextList[j]
               # If Levenshtein distance is 1.0, then only check if comment text is exactly the same
               if levenshtein == 1.0 and x == y: 
-                uniqueMatches += 2
+                matchedIndexes.add(i)
+                matchedIndexes.add(j)
                 break
               # If Levenshtein distance is 0, don't check at all, just count number of comments by user
               elif levenshtein == 0.0:
-                uniqueMatches += 2
+                matchedIndexes.add(i)
+                matchedIndexes.add(j)
                 break
               elif fuzz.ratio(x,y) / 100 > levenshtein:
                 # List the indexes of the matched comments in the list
-                uniqueMatches += 2
+                matchedIndexes.add(i)
+                matchedIndexes.add(j)
                 break
           else:
             break
         
         # Only count each comment once by counting number of unique indexes in matchedIndexes
+        uniqueMatches = len(matchedIndexes)
         if uniqueMatches >= minimum_duplicates:
           numDupes += uniqueMatches
       if numDupes > 0:


### PR DESCRIPTION
previously indexs were being added to a list and then its only use was to get the length I have changed the code to instead have it be a number

### Related Issue/Addition to code
<!-- Please delete options that are not relevant. -->

- Addition to code.

### Proposed Changes
- replace check_duplicate's list with set
- change domains list so every element has a dot in front

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It speeds up the checking of duplicate comments

### Additional Info
- the only time the list is used other than when being added is having its length checked

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
