### PR TITLE
Fix dividing by zero

### DIFF
--- a/Scripts/community_downloader.py
+++ b/Scripts/community_downloader.py
@@ -231,7 +231,7 @@ def main(communityPostID=None, limit=1000, sort=SORT_BY_RECENT, language=None, p
         if comment['totalPostComments']:
             totalComments = comment['totalPostComments']
         
-        if totalComments >= 0:
+        if totalComments >= 1:
             percent = ((count / totalComments) * 100)
             progressStats = f"[ {str(count)} / {str(totalComments)} ]".ljust(15, " ") + f" ({percent:.2f}%)"
             print(f'    >  Retrieving Post Comments - {progressStats}', end='\r')


### PR DESCRIPTION
### Related Issue
<!-- Please delete options that are not relevant. -->

- Fixes #1078 

### Explanation
It happened if the number of comments is 0, it would still try to get the percent, dividing the `count` by `totalComments`, in which case, if there were 0 comments, it would divide by 0.

https://github.com/ThioJoe/YT-Spammer-Purge/blob/91816f312807454b74a93abd3d6849cf4af3fac5/Scripts/community_downloader.py#L234