### PR TITLE
ennabled Text mode for nonchannel owners YTSpammerPurge.py

### DIFF
--- a/YTSpammerPurge.py
+++ b/YTSpammerPurge.py
@@ -1345,9 +1345,9 @@ def main():
     deletionMode = None # Should be changed later, but if missed it will default to heldForReview
     confirmDelete = None # If None, will later cause user to be asked to delete
     if moderator_mode == False:
-      filterModesAllowedforNonOwners = ["AutoSmart", "SensitiveSmart"]
+      filterModesAllowedforNonOwners = ["AutoSmart", "SensitiveSmart", "Text"]
     elif moderator_mode == True:
-      filterModesAllowedforNonOwners = ["AutoSmart", "SensitiveSmart", 'ID']
+      filterModesAllowedforNonOwners = ["AutoSmart", "SensitiveSmart", "Text", 'ID']
 
     # If user isn't channel owner and not using allowed filter mode, skip deletion
     if userNotChannelOwner == True and filterMode not in filterModesAllowedforNonOwners:


### PR DESCRIPTION
### Related Issue/Addition to code
- Fixes (im not gonna listing off the issues this fixes since there are alot)

#### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Proposed Changes
- allow non owners to use text mode

### Why is this change needed?
 There are many spam bots that add additional randomized characters which prevents the duplicate checker since they are not completely identical

### Additional Info
- I could not find the reason it is disabled for non-owners so if you know feel free to let me know and i might close this because of that reason

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
