### PR TITLE
Fix the "externally-managed-environment" pip error.

### DIFF
--- a/YTSpammerPurge.sh
+++ b/YTSpammerPurge.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+ScriptDir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+$ScriptDir/venv/bin/python3 $ScriptDir/YTSpammerPurge.py

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,9 @@ install_macos() {
 }
 
 install_python_requirements () {
-    python3 -m pip install -q -r requirements.txt --user && \
+    python3 -m venv venv
+    source venv/bin/activate
+    python3 -m pip install -q -r requirements.txt && \
         echo "Python requirements installed." || exit 1
     # Pip should give an error if it fails.
 }
@@ -174,7 +176,7 @@ install_MAIN () {
 
     # Done!
 
-    printf "Dependencies and Program installed into .\YT-Spammer-Purge!\nNow follow these instructions to get a client_secrets.json file!\nhttps://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key\n\nYou may run this script again inside your installation to update.\n"
+    printf "Dependencies and Program installed into this folder.\nYou may now follow these instructions to get a client_secrets.json file!\nhttps://github.com/ThioJoe/YT-Spammer-Purge/wiki/Instructions:-Obtaining-an-API-Key and run the ./YTSpammerPurge.sh script.\n\nYou may run this script again inside your installation to update.\n"
     exit 0
 }
 


### PR DESCRIPTION
### Related Issue/Addition to code

- Fixed the "externally-managed-environment" error that pip gives when the script tries to install python modules.
- Added a bash script to start this, and also referenced it in the post-installation notes for the script.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### Why is this change needed?
<!-- How will this change benefit YT-Spammer-Purge? --> 
It's needed for installing this without that error.

### Additional Info
- I made it so the install script makes a virtual environment called "venv" in the script's folder to avoid the error.

### Checklist:

- [x] My code follows the style guidelines of this project and I have read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (very simple changes so not needed)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---

### Screenshots

Not needed.